### PR TITLE
회원가입 및 로그인 관련 API 추가

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,6 +30,13 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
         manifestPlaceholders["MAPS_API_KEY"] = localProperties.getProperty("MAPS_API_KEY")
+        manifestPlaceholders["KAKAO_NATIVE_APP_KEY"] = localProperties.getProperty("KAKAO_NATIVE_APP_KEY", "")
+
+        buildConfigField(
+            "String",
+            "KAKAO_NATIVE_APP_KEY",
+            "\"${localProperties.getProperty("KAKAO_NATIVE_APP_KEY", "")}\""
+        )
     }
 
     buildTypes {
@@ -47,6 +54,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 }
 
@@ -94,6 +102,8 @@ dependencies {
     implementation(libs.androidx.compose.material3.adaptive.navigation3)
     implementation(libs.androidx.compose.material3.navigationSuite)
     implementation(libs.androidx.hilt.lifecycle.viewModelCompose)
+
+    implementation(libs.kakao.user)
 
     //TODO for test
     api(libs.androidx.compose.material.iconsExtended)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,19 @@
             android:value = "${MAPS_API_KEY}"/>
 
         <activity
+            android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:host="oauth"
+                    android:scheme="kakao${KAKAO_NATIVE_APP_KEY}" />
+            </intent-filter>
+        </activity>
+
+        <activity
             android:name=".WitActivity"
             android:exported="true"
             android:label="@string/app_name"

--- a/app/src/main/java/com/multissue/wit/WitActivity.kt
+++ b/app/src/main/java/com/multissue/wit/WitActivity.kt
@@ -7,35 +7,46 @@ import android.view.View
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
+import androidx.activity.viewModels
+import androidx.compose.runtime.getValue
 import androidx.core.view.WindowCompat
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.multissue.wit.designsystem.component.dialog.WitReLoginDialog
 import com.multissue.wit.designsystem.theme.WitTheme
 import com.multissue.wit.ui.root.RootApp
+import com.multissue.wit.ui.root.RootViewModel
+import com.multissue.wit.ui.root.StartDestination
 import com.multissue.wit.ui.root.rememberRootAppState
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class WitActivity : ComponentActivity() {
+
+    private val rootViewModel: RootViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         WindowCompat.getInsetsController(window, window.decorView)
             .isAppearanceLightStatusBars = true //TODO 다크모드 대응 시 교체 필요
-//        setNavigationBarColorCompat(
-//            color = Color.White.toArgb(),
-//            isLightBar = true
-//        )
-//        setStatusBarColorCompat(
-//            color = Color.White.toArgb(),
-//            isLightBar = true
-//        )
 
         setContent {
-            val appState = rememberRootAppState()
+            val startDestination by rootViewModel.startDestination.collectAsStateWithLifecycle()
+            val showReLoginDialog by rootViewModel.showReLoginDialog.collectAsStateWithLifecycle()
 
             WitTheme {
-                RootApp(appState)
+                val appState = rememberRootAppState(
+                    startFromMain = startDestination == StartDestination.Main
+                )
+                RootApp(appState = appState)
+
+                WitReLoginDialog(
+                    visible = showReLoginDialog,
+                    onConfirm = {
+                        rootViewModel.onReLoginConfirmed()
+                        appState.navigateToAuth()
+                    }
+                )
             }
         }
     }

--- a/app/src/main/java/com/multissue/wit/WitApplication.kt
+++ b/app/src/main/java/com/multissue/wit/WitApplication.kt
@@ -1,7 +1,19 @@
 package com.multissue.wit
 
 import android.app.Application
+import android.util.Log
+import com.kakao.sdk.common.KakaoSdk
+import com.kakao.sdk.common.util.Utility
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
-class WitApplication: Application()
+class WitApplication : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+        KakaoSdk.init(this, BuildConfig.KAKAO_NATIVE_APP_KEY)
+        if (BuildConfig.DEBUG) {
+            Log.d("WitApplication", "KeyHash: ${Utility.getKeyHash(this)}")
+        }
+    }
+}

--- a/app/src/main/java/com/multissue/wit/navigation/AuthLevelNavItem.kt
+++ b/app/src/main/java/com/multissue/wit/navigation/AuthLevelNavItem.kt
@@ -19,8 +19,6 @@ package com.multissue.wit.navigation
 import com.multissue.wit.feature.login.navigation.LoginNavKey
 import com.multissue.wit.feature.onboarding.navigation.OnboardingNavKey
 import com.multissue.wit.feature.signup.navigation.SignupNavKey
-import com.multissue.wit.navigation.auth.AuthNavKey
-import com.multissue.wit.navigation.main.MainNavKey
 
 data object AuthLevelNavItem
 

--- a/app/src/main/java/com/multissue/wit/navigation/main/MainEntryProvider.kt
+++ b/app/src/main/java/com/multissue/wit/navigation/main/MainEntryProvider.kt
@@ -2,16 +2,18 @@ package com.multissue.wit.navigation.main
 
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
-import com.multissue.wit.core.navigation.Navigator
-import com.multissue.wit.designsystem.theme.WitTheme
-import com.multissue.wit.feature.onboarding.OnboardingScreen
 import com.multissue.wit.ui.main.WitApp
 import com.multissue.wit.ui.main.rememberWitAppState
 
-fun EntryProviderScope<NavKey>.mainEntry(navigator: Navigator) {
+fun EntryProviderScope<NavKey>.mainEntry(
+    onNavigateToAuth: () -> Unit,
+) {
     // TODO SnackBar
     entry<MainNavKey> {
         val appState = rememberWitAppState()
-        WitApp(appState)
+        WitApp(
+            appState = appState,
+            onNavigateToAuth = onNavigateToAuth,
+        )
     }
 }

--- a/app/src/main/java/com/multissue/wit/ui/auth/AuthApp.kt
+++ b/app/src/main/java/com/multissue/wit/ui/auth/AuthApp.kt
@@ -28,16 +28,13 @@ fun AuthApp(
     val navigator = remember { Navigator(authState.navigationState) }
     val listDetailStrategy = rememberListDetailSceneStrategy<NavKey>()
 
-//    LaunchedEffect(Unit) {
-//        navigateToMain()
-//    }
-
     val entryProvider = entryProvider {
         onboardingEntry {
             navigator.navigate(LoginNavKey)
         }
         loginEntry(
-            navigateToSignUp = { navigator.navigate(SignupNavKey) }
+            navigateToSignUp = { navigator.navigate(SignupNavKey) },
+            navigateToMain = navigateToMain,
         )
         signupEntry(
             navigateToLogin = { navigator.navigate(LoginNavKey) },

--- a/app/src/main/java/com/multissue/wit/ui/main/WitApp.kt
+++ b/app/src/main/java/com/multissue/wit/ui/main/WitApp.kt
@@ -54,11 +54,13 @@ import kotlinx.coroutines.flow.map
 @Composable
 fun WitApp(
     appState: WitAppState,
+    onNavigateToAuth: () -> Unit = {},
 ) {
     // TODO THEMES
     WitApp(
         appState = appState,
-        witAppViewModel = hiltViewModel()
+        witAppViewModel = hiltViewModel(),
+        onNavigateToAuth = onNavigateToAuth,
     )
 }
 
@@ -67,6 +69,7 @@ fun WitApp(
 internal fun WitApp(
     appState: WitAppState,
     witAppViewModel: WitAppViewModel,
+    onNavigateToAuth: () -> Unit = {},
 ) {
     val navigator = remember { Navigator(appState.navigationState) }
     var showNavRail by remember { mutableStateOf(true) }
@@ -112,8 +115,8 @@ internal fun WitApp(
                         onNavigateToUpload = { navigator.navigate(UploadNavKey) },
                     )
                     myPageEntry(
-                        navigator,
                         onBottomNavVisibilityChanged = { showNavRail = it },
+                        onNavigateToAuth = onNavigateToAuth,
                     )
                     uploadEntry(navigator)
                     feedEntry(navigator)

--- a/app/src/main/java/com/multissue/wit/ui/root/RootApp.kt
+++ b/app/src/main/java/com/multissue/wit/ui/root/RootApp.kt
@@ -3,24 +3,19 @@ package com.multissue.wit.ui.root
 import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
 import androidx.compose.material3.adaptive.navigation3.rememberListDetailSceneStrategy
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
-import androidx.compose.ui.Modifier
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.ui.NavDisplay
-import com.multissue.wit.core.navigation.Navigator
 import com.multissue.wit.core.navigation.toEntries
 import com.multissue.wit.navigation.auth.authEntry
 import com.multissue.wit.navigation.main.mainEntry
-import com.multissue.wit.ui.main.WitAppState
 
 @OptIn(ExperimentalMaterial3AdaptiveApi::class)
 @Composable
 fun RootApp(
-    appState: RootAppState,
-    modifier: Modifier = Modifier,
+    appState: RootAppState
 ) {
-    val navigator = remember { Navigator(appState.navigationState) }
+    val navigator = appState.navigator
     val listDetailStrategy = rememberListDetailSceneStrategy<NavKey>()
 
     val entryProvider = entryProvider {

--- a/app/src/main/java/com/multissue/wit/ui/root/RootApp.kt
+++ b/app/src/main/java/com/multissue/wit/ui/root/RootApp.kt
@@ -20,7 +20,9 @@ fun RootApp(
 
     val entryProvider = entryProvider {
         authEntry(navigator)
-        mainEntry(navigator)
+        mainEntry(
+            onNavigateToAuth = appState::navigateToAuth
+        )
     }
 
     NavDisplay(

--- a/app/src/main/java/com/multissue/wit/ui/root/RootAppState.kt
+++ b/app/src/main/java/com/multissue/wit/ui/root/RootAppState.kt
@@ -5,17 +5,21 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import com.multissue.wit.core.navigation.NavigationState
+import com.multissue.wit.core.navigation.Navigator
 import com.multissue.wit.core.navigation.rememberNavigationState
 import com.multissue.wit.navigation.ROOT_LEVEL_NAV_ITEMS
 import com.multissue.wit.navigation.auth.AuthNavKey
+import com.multissue.wit.navigation.main.MainNavKey
 import com.multissue.wit.ui.main.NavigationTrackingSideEffect
 import kotlinx.coroutines.CoroutineScope
 
 @Composable
 fun rememberRootAppState(
+    startFromMain: Boolean,
     coroutineScope: CoroutineScope = rememberCoroutineScope(),
 ): RootAppState {
-    val navigationState = rememberNavigationState(AuthNavKey, ROOT_LEVEL_NAV_ITEMS.keys)
+    val startKey = if (startFromMain) MainNavKey else AuthNavKey
+    val navigationState = rememberNavigationState(startKey, ROOT_LEVEL_NAV_ITEMS.keys)
 
     NavigationTrackingSideEffect(navigationState)
 
@@ -35,5 +39,9 @@ class RootAppState(
     val navigationState: NavigationState,
     coroutineScope: CoroutineScope,
 ) {
-    // TODO 구현할 거 있으면
+    val navigator = Navigator(navigationState)
+
+    fun navigateToAuth() {
+        navigator.navigate(AuthNavKey)
+    }
 }

--- a/app/src/main/java/com/multissue/wit/ui/root/RootViewModel.kt
+++ b/app/src/main/java/com/multissue/wit/ui/root/RootViewModel.kt
@@ -1,0 +1,47 @@
+package com.multissue.wit.ui.root
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.multissue.wit.core.domain.usecase.auth.AutoLoginUseCase
+import com.multissue.wit.core.network.auth.AuthEvent
+import com.multissue.wit.core.network.auth.AuthEventBus
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class RootViewModel @Inject constructor(
+    autoLoginUseCase: AutoLoginUseCase,
+    private val authEventBus: AuthEventBus,
+) : ViewModel() {
+
+    private val _startDestination = MutableStateFlow(
+        if (autoLoginUseCase()) StartDestination.Main else StartDestination.Auth
+    )
+    val startDestination: StateFlow<StartDestination> = _startDestination
+
+    private val _showReLoginDialog = MutableStateFlow(false)
+    val showReLoginDialog: StateFlow<Boolean> = _showReLoginDialog
+
+    init {
+        viewModelScope.launch {
+            authEventBus.events.collect { event ->
+                when (event) {
+                    AuthEvent.TokenExpired -> _showReLoginDialog.value = true
+                }
+            }
+        }
+    }
+
+    fun onReLoginConfirmed() {
+        _showReLoginDialog.value = false
+        _startDestination.value = StartDestination.Auth
+    }
+}
+
+sealed interface StartDestination {
+    data object Auth : StartDestination
+    data object Main : StartDestination
+}

--- a/build-logic/convention/src/main/java/com/multissue/convention/plugins/AndroidKotlinPlugin.kt
+++ b/build-logic/convention/src/main/java/com/multissue/convention/plugins/AndroidKotlinPlugin.kt
@@ -23,6 +23,8 @@ class AndroidKotlinPlugin : Plugin<Project> {
                     freeCompilerArgs.addAll(
                         listOf(
                             "-opt-in=kotlin.RequiresOptIn",
+                            "-opt-in=kotlinx.serialization.InternalSerializationApi",
+                            "-opt-in=kotlinx.serialization.ExperimentalSerializationApi",
                         ),
                     )
                     jvmTarget.set(JvmTarget.JVM_17)

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -8,4 +8,5 @@ plugins {
 dependencies {
     implementation(projects.core.domain)
     implementation(projects.core.network)
+    implementation(projects.core.datastore)
 }

--- a/core/data/src/main/java/com/multissue/wit/core/data/di/AuthDataModule.kt
+++ b/core/data/src/main/java/com/multissue/wit/core/data/di/AuthDataModule.kt
@@ -1,0 +1,20 @@
+package com.multissue.wit.core.data.di
+
+import com.multissue.wit.core.data.repository.AuthRepositoryImpl
+import com.multissue.wit.core.domain.repository.AuthRepository
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class AuthDataModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindAuthRepository(
+        impl: AuthRepositoryImpl,
+    ): AuthRepository
+}

--- a/core/data/src/main/java/com/multissue/wit/core/data/di/TermsDataModule.kt
+++ b/core/data/src/main/java/com/multissue/wit/core/data/di/TermsDataModule.kt
@@ -1,0 +1,20 @@
+package com.multissue.wit.core.data.di
+
+import com.multissue.wit.core.data.repository.TermsRepositoryImpl
+import com.multissue.wit.core.domain.repository.TermsRepository
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class TermsDataModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindTermsRepository(
+        impl: TermsRepositoryImpl,
+    ): TermsRepository
+}

--- a/core/data/src/main/java/com/multissue/wit/core/data/di/UserDataModule.kt
+++ b/core/data/src/main/java/com/multissue/wit/core/data/di/UserDataModule.kt
@@ -1,0 +1,20 @@
+package com.multissue.wit.core.data.di
+
+import com.multissue.wit.core.data.repository.UserRepositoryImpl
+import com.multissue.wit.core.domain.repository.UserRepository
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class UserDataModule {
+
+    @Binds
+    @Singleton
+    abstract fun bindUserRepository(
+        impl: UserRepositoryImpl,
+    ): UserRepository
+}

--- a/core/data/src/main/java/com/multissue/wit/core/data/mapper/AuthMapper.kt
+++ b/core/data/src/main/java/com/multissue/wit/core/data/mapper/AuthMapper.kt
@@ -1,0 +1,12 @@
+package com.multissue.wit.core.data.mapper
+
+import com.multissue.wit.core.domain.model.auth.AuthStatus
+import com.multissue.wit.core.domain.model.auth.LoginResult
+import com.multissue.wit.core.network.model.auth.response.SocialLoginResponse
+
+fun SocialLoginResponse.toDomain() = LoginResult(
+    status = runCatching {
+        AuthStatus.valueOf(status)
+    }.getOrDefault(AuthStatus.PENDING_AGREEMENT),
+    // TODO: 서버 응답에 따라 필요한 필드 매핑 추가
+)

--- a/core/data/src/main/java/com/multissue/wit/core/data/mapper/AuthMapper.kt
+++ b/core/data/src/main/java/com/multissue/wit/core/data/mapper/AuthMapper.kt
@@ -8,5 +8,6 @@ fun SocialLoginResponse.toDomain() = LoginResult(
     status = runCatching {
         AuthStatus.valueOf(status)
     }.getOrDefault(AuthStatus.PENDING_AGREEMENT),
-    // TODO: 서버 응답에 따라 필요한 필드 매핑 추가
+    nickname = nickname,
+    profileImagePath = profileImagePath,
 )

--- a/core/data/src/main/java/com/multissue/wit/core/data/mapper/TermsMapper.kt
+++ b/core/data/src/main/java/com/multissue/wit/core/data/mapper/TermsMapper.kt
@@ -1,0 +1,13 @@
+package com.multissue.wit.core.data.mapper
+
+import com.multissue.wit.core.domain.model.terms.TermItem
+import com.multissue.wit.core.network.model.terms.response.TermItemResponse
+
+fun TermItemResponse.toDomain() = TermItem(
+    id = id,
+    type = type,
+    title = title,
+    required = required,
+    version = version,
+    contentUrl = contentUrl,
+)

--- a/core/data/src/main/java/com/multissue/wit/core/data/mapper/UserMapper.kt
+++ b/core/data/src/main/java/com/multissue/wit/core/data/mapper/UserMapper.kt
@@ -1,0 +1,12 @@
+package com.multissue.wit.core.data.mapper
+
+import com.multissue.wit.core.domain.model.user.UserInfo
+import com.multissue.wit.core.network.model.user.response.UserInfoResponse
+
+fun UserInfoResponse.toDomain() = UserInfo(
+    nickname = nickname,
+    profileImagePath = profileImagePath,
+    age = age,
+    gender = gender,
+    isOwner = isOwner,
+)

--- a/core/data/src/main/java/com/multissue/wit/core/data/repository/AuthRepositoryImpl.kt
+++ b/core/data/src/main/java/com/multissue/wit/core/data/repository/AuthRepositoryImpl.kt
@@ -1,14 +1,13 @@
 package com.multissue.wit.core.data.repository
 
 import com.multissue.wit.core.data.mapper.toDomain
-import com.multissue.wit.core.datastore.storage.Storage
-import com.multissue.wit.core.datastore.token.WitStorageKeys
 import com.multissue.wit.core.domain.exception.WitException
 import com.multissue.wit.core.domain.model.auth.LoginResult
 import com.multissue.wit.core.domain.model.auth.SocialType
 import com.multissue.wit.core.domain.repository.AuthRepository
 import com.multissue.wit.core.network.Dispatcher
 import com.multissue.wit.core.network.WitDispatchers
+import com.multissue.wit.core.network.interceptor.TokenProvider
 import com.multissue.wit.core.network.model.ApiResponse
 import com.multissue.wit.core.network.model.auth.request.SocialLoginRequest
 import com.multissue.wit.core.network.service.AuthService
@@ -19,7 +18,7 @@ import javax.inject.Inject
 
 class AuthRepositoryImpl @Inject constructor(
     private val authService: AuthService,
-    private val storage: Storage,
+    private val tokenProvider: TokenProvider,
     @Dispatcher(WitDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
 ) : AuthRepository {
 
@@ -34,8 +33,7 @@ class AuthRepositoryImpl @Inject constructor(
         when (val response = safeApiCall { authService.socialLogin(request) }) {
             is ApiResponse.Success -> {
                 val data = response.data.data!!
-                storage.writeValue(WitStorageKeys.ACCESS_TOKEN, data.accessToken)
-                storage.writeValue(WitStorageKeys.REFRESH_TOKEN, data.refreshToken)
+                tokenProvider.saveTokens(data.accessToken, data.refreshToken)
                 Result.success(data.toDomain())
             }
             is ApiResponse.Failure -> Result.failure(
@@ -45,5 +43,11 @@ class AuthRepositoryImpl @Inject constructor(
                 WitException.NetworkException(response.throwable)
             )
         }
+    }
+
+    override fun hasAccessToken(): Boolean = tokenProvider.getAccessToken() != null
+
+    override suspend fun clearTokens() {
+        tokenProvider.clearTokens()
     }
 }

--- a/core/data/src/main/java/com/multissue/wit/core/data/repository/AuthRepositoryImpl.kt
+++ b/core/data/src/main/java/com/multissue/wit/core/data/repository/AuthRepositoryImpl.kt
@@ -1,0 +1,49 @@
+package com.multissue.wit.core.data.repository
+
+import com.multissue.wit.core.data.mapper.toDomain
+import com.multissue.wit.core.datastore.storage.Storage
+import com.multissue.wit.core.datastore.token.WitStorageKeys
+import com.multissue.wit.core.domain.exception.WitException
+import com.multissue.wit.core.domain.model.auth.LoginResult
+import com.multissue.wit.core.domain.model.auth.SocialType
+import com.multissue.wit.core.domain.repository.AuthRepository
+import com.multissue.wit.core.network.Dispatcher
+import com.multissue.wit.core.network.WitDispatchers
+import com.multissue.wit.core.network.model.ApiResponse
+import com.multissue.wit.core.network.model.auth.request.SocialLoginRequest
+import com.multissue.wit.core.network.service.AuthService
+import com.multissue.wit.core.network.util.safeApiCall
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class AuthRepositoryImpl @Inject constructor(
+    private val authService: AuthService,
+    private val storage: Storage,
+    @Dispatcher(WitDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
+) : AuthRepository {
+
+    override suspend fun socialLogin(
+        socialType: SocialType,
+        token: String,
+    ): Result<LoginResult> = withContext(ioDispatcher) {
+        val request = SocialLoginRequest(
+            socialType = socialType.name,
+            token = token,
+        )
+        when (val response = safeApiCall { authService.socialLogin(request) }) {
+            is ApiResponse.Success -> {
+                val data = response.data.data
+                storage.writeValue(WitStorageKeys.ACCESS_TOKEN, data.accessToken)
+                storage.writeValue(WitStorageKeys.REFRESH_TOKEN, data.refreshToken)
+                Result.success(data.toDomain())
+            }
+            is ApiResponse.Failure -> Result.failure(
+                WitException.HttpException(response.code, response.message)
+            )
+            is ApiResponse.NetworkError -> Result.failure(
+                WitException.NetworkException(response.throwable)
+            )
+        }
+    }
+}

--- a/core/data/src/main/java/com/multissue/wit/core/data/repository/AuthRepositoryImpl.kt
+++ b/core/data/src/main/java/com/multissue/wit/core/data/repository/AuthRepositoryImpl.kt
@@ -33,7 +33,7 @@ class AuthRepositoryImpl @Inject constructor(
         )
         when (val response = safeApiCall { authService.socialLogin(request) }) {
             is ApiResponse.Success -> {
-                val data = response.data.data
+                val data = response.data.data!!
                 storage.writeValue(WitStorageKeys.ACCESS_TOKEN, data.accessToken)
                 storage.writeValue(WitStorageKeys.REFRESH_TOKEN, data.refreshToken)
                 Result.success(data.toDomain())

--- a/core/data/src/main/java/com/multissue/wit/core/data/repository/AuthRepositoryImpl.kt
+++ b/core/data/src/main/java/com/multissue/wit/core/data/repository/AuthRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.multissue.wit.core.data.repository
 
 import com.multissue.wit.core.data.mapper.toDomain
 import com.multissue.wit.core.domain.exception.WitException
+import com.multissue.wit.core.domain.model.auth.AuthStatus
 import com.multissue.wit.core.domain.model.auth.LoginResult
 import com.multissue.wit.core.domain.model.auth.SocialType
 import com.multissue.wit.core.domain.repository.AuthRepository
@@ -34,6 +35,7 @@ class AuthRepositoryImpl @Inject constructor(
             is ApiResponse.Success -> {
                 val data = response.data.data!!
                 tokenProvider.saveTokens(data.accessToken, data.refreshToken)
+                tokenProvider.saveUserStatus(data.status)
                 Result.success(data.toDomain())
             }
             is ApiResponse.Failure -> Result.failure(
@@ -46,6 +48,14 @@ class AuthRepositoryImpl @Inject constructor(
     }
 
     override fun hasAccessToken(): Boolean = tokenProvider.getAccessToken() != null
+
+    override fun getUserStatus(): AuthStatus? = tokenProvider.getUserStatus()?.let { status ->
+        runCatching { AuthStatus.valueOf(status) }.getOrNull()
+    }
+
+    override suspend fun saveUserStatus(status: AuthStatus) {
+        tokenProvider.saveUserStatus(status.name)
+    }
 
     override suspend fun logout(): Result<Unit> = withContext(ioDispatcher) {
         when (val response = safeApiCall { authService.logout() }) {

--- a/core/data/src/main/java/com/multissue/wit/core/data/repository/AuthRepositoryImpl.kt
+++ b/core/data/src/main/java/com/multissue/wit/core/data/repository/AuthRepositoryImpl.kt
@@ -47,6 +47,21 @@ class AuthRepositoryImpl @Inject constructor(
 
     override fun hasAccessToken(): Boolean = tokenProvider.getAccessToken() != null
 
+    override suspend fun logout(): Result<Unit> = withContext(ioDispatcher) {
+        when (val response = safeApiCall { authService.logout() }) {
+            is ApiResponse.Success -> {
+                tokenProvider.clearTokens()
+                Result.success(Unit)
+            }
+            is ApiResponse.Failure -> {
+                Result.failure(WitException.HttpException(response.code, response.message))
+            }
+            is ApiResponse.NetworkError -> {
+                Result.failure(WitException.NetworkException(response.throwable))
+            }
+        }
+    }
+
     override suspend fun clearTokens() {
         tokenProvider.clearTokens()
     }

--- a/core/data/src/main/java/com/multissue/wit/core/data/repository/TermsRepositoryImpl.kt
+++ b/core/data/src/main/java/com/multissue/wit/core/data/repository/TermsRepositoryImpl.kt
@@ -7,6 +7,7 @@ import com.multissue.wit.core.domain.repository.TermsRepository
 import com.multissue.wit.core.network.Dispatcher
 import com.multissue.wit.core.network.WitDispatchers
 import com.multissue.wit.core.network.model.ApiResponse
+import com.multissue.wit.core.network.interceptor.TokenProvider
 import com.multissue.wit.core.network.model.terms.request.AgreeTermsRequest
 import com.multissue.wit.core.network.model.terms.request.TermAgreement
 import com.multissue.wit.core.network.service.TermsService
@@ -17,6 +18,7 @@ import javax.inject.Inject
 
 class TermsRepositoryImpl @Inject constructor(
     private val termsService: TermsService,
+    private val tokenProvider: TokenProvider,
     @Dispatcher(WitDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
 ) : TermsRepository {
 
@@ -46,6 +48,7 @@ class TermsRepositoryImpl @Inject constructor(
             when (val response = safeApiCall { termsService.agreeTerms(request) }) {
                 is ApiResponse.Success -> {
                     val userStatus = response.data.data?.userStatus ?: ""
+                    tokenProvider.saveUserStatus(userStatus)
                     Result.success(userStatus)
                 }
                 is ApiResponse.Failure -> Result.failure(

--- a/core/data/src/main/java/com/multissue/wit/core/data/repository/TermsRepositoryImpl.kt
+++ b/core/data/src/main/java/com/multissue/wit/core/data/repository/TermsRepositoryImpl.kt
@@ -1,0 +1,59 @@
+package com.multissue.wit.core.data.repository
+
+import com.multissue.wit.core.data.mapper.toDomain
+import com.multissue.wit.core.domain.exception.WitException
+import com.multissue.wit.core.domain.model.terms.TermItem
+import com.multissue.wit.core.domain.repository.TermsRepository
+import com.multissue.wit.core.network.Dispatcher
+import com.multissue.wit.core.network.WitDispatchers
+import com.multissue.wit.core.network.model.ApiResponse
+import com.multissue.wit.core.network.model.terms.request.AgreeTermsRequest
+import com.multissue.wit.core.network.model.terms.request.TermAgreement
+import com.multissue.wit.core.network.service.TermsService
+import com.multissue.wit.core.network.util.safeApiCall
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class TermsRepositoryImpl @Inject constructor(
+    private val termsService: TermsService,
+    @Dispatcher(WitDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
+) : TermsRepository {
+
+    override suspend fun getActiveTerms(): Result<List<TermItem>> =
+        withContext(ioDispatcher) {
+            when (val response = safeApiCall { termsService.getActiveTerms() }) {
+                is ApiResponse.Success -> {
+                    val terms = response.data.data?.terms?.map { it.toDomain() } ?: emptyList()
+                    Result.success(terms)
+                }
+                is ApiResponse.Failure -> Result.failure(
+                    WitException.HttpException(response.code, response.message)
+                )
+                is ApiResponse.NetworkError -> Result.failure(
+                    WitException.NetworkException(response.throwable)
+                )
+            }
+        }
+
+    override suspend fun agreeTerms(agreements: List<Pair<String, Boolean>>): Result<String> =
+        withContext(ioDispatcher) {
+            val request = AgreeTermsRequest(
+                terms = agreements.map { (termId, agreed) ->
+                    TermAgreement(termId = termId, agreed = agreed)
+                }
+            )
+            when (val response = safeApiCall { termsService.agreeTerms(request) }) {
+                is ApiResponse.Success -> {
+                    val userStatus = response.data.data?.userStatus ?: ""
+                    Result.success(userStatus)
+                }
+                is ApiResponse.Failure -> Result.failure(
+                    WitException.HttpException(response.code, response.message)
+                )
+                is ApiResponse.NetworkError -> Result.failure(
+                    WitException.NetworkException(response.throwable)
+                )
+            }
+        }
+}

--- a/core/data/src/main/java/com/multissue/wit/core/data/repository/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/multissue/wit/core/data/repository/UserRepositoryImpl.kt
@@ -1,0 +1,29 @@
+package com.multissue.wit.core.data.repository
+
+import com.multissue.wit.core.domain.exception.WitException
+import com.multissue.wit.core.domain.repository.UserRepository
+import com.multissue.wit.core.network.Dispatcher
+import com.multissue.wit.core.network.WitDispatchers
+import com.multissue.wit.core.network.model.ApiResponse
+import com.multissue.wit.core.network.service.UserService
+import com.multissue.wit.core.network.util.safeApiCall
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class UserRepositoryImpl @Inject constructor(
+    private val userService: UserService,
+    @Dispatcher(WitDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
+) : UserRepository {
+
+    override suspend fun checkNicknameDuplicate(nickname: String): Result<Boolean> =
+        withContext(ioDispatcher) {
+            when (val response = safeApiCall { userService.checkNicknameDuplicate(nickname) }) {
+                is ApiResponse.Success -> Result.success(true)
+                is ApiResponse.Failure -> Result.failure(WitException.HttpException(response.code, response.message))
+                is ApiResponse.NetworkError -> Result.failure(
+                    WitException.NetworkException(response.throwable)
+                )
+            }
+        }
+}

--- a/core/data/src/main/java/com/multissue/wit/core/data/repository/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/multissue/wit/core/data/repository/UserRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.multissue.wit.core.domain.repository.UserRepository
 import com.multissue.wit.core.network.Dispatcher
 import com.multissue.wit.core.network.WitDispatchers
 import com.multissue.wit.core.network.model.ApiResponse
+import com.multissue.wit.core.network.model.user.request.OnboardingRequest
 import com.multissue.wit.core.network.service.UserService
 import com.multissue.wit.core.network.util.safeApiCall
 import kotlinx.coroutines.CoroutineDispatcher
@@ -26,4 +27,27 @@ class UserRepositoryImpl @Inject constructor(
                 )
             }
         }
+
+    override suspend fun completeOnboarding(
+        nickname: String,
+        gender: String,
+        birthDate: String,
+        profileImagePath: String?,
+    ): Result<Unit> = withContext(ioDispatcher) {
+        val request = OnboardingRequest(
+            nickname = nickname,
+            gender = gender,
+            birthDate = birthDate,
+            profileImagePath = profileImagePath,
+        )
+        when (val response = safeApiCall { userService.completeOnboarding(request) }) {
+            is ApiResponse.Success -> Result.success(Unit)
+            is ApiResponse.Failure -> Result.failure(
+                WitException.HttpException(response.code, response.message)
+            )
+            is ApiResponse.NetworkError -> Result.failure(
+                WitException.NetworkException(response.throwable)
+            )
+        }
+    }
 }

--- a/core/data/src/main/java/com/multissue/wit/core/data/repository/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/multissue/wit/core/data/repository/UserRepositoryImpl.kt
@@ -1,6 +1,8 @@
 package com.multissue.wit.core.data.repository
 
+import com.multissue.wit.core.data.mapper.toDomain
 import com.multissue.wit.core.domain.exception.WitException
+import com.multissue.wit.core.domain.model.user.UserInfo
 import com.multissue.wit.core.domain.repository.UserRepository
 import com.multissue.wit.core.network.Dispatcher
 import com.multissue.wit.core.network.WitDispatchers
@@ -42,6 +44,18 @@ class UserRepositoryImpl @Inject constructor(
         )
         when (val response = safeApiCall { userService.completeOnboarding(request) }) {
             is ApiResponse.Success -> Result.success(Unit)
+            is ApiResponse.Failure -> Result.failure(
+                WitException.HttpException(response.code, response.message)
+            )
+            is ApiResponse.NetworkError -> Result.failure(
+                WitException.NetworkException(response.throwable)
+            )
+        }
+    }
+
+    override suspend fun getMyInfo(): Result<UserInfo> = withContext(ioDispatcher) {
+        when (val response = safeApiCall { userService.getMyInfo() }) {
+            is ApiResponse.Success -> Result.success(response.data.data!!.toDomain())
             is ApiResponse.Failure -> Result.failure(
                 WitException.HttpException(response.code, response.message)
             )

--- a/core/data/src/main/java/com/multissue/wit/core/data/repository/UserRepositoryImpl.kt
+++ b/core/data/src/main/java/com/multissue/wit/core/data/repository/UserRepositoryImpl.kt
@@ -7,6 +7,7 @@ import com.multissue.wit.core.domain.repository.UserRepository
 import com.multissue.wit.core.network.Dispatcher
 import com.multissue.wit.core.network.WitDispatchers
 import com.multissue.wit.core.network.model.ApiResponse
+import com.multissue.wit.core.network.interceptor.TokenProvider
 import com.multissue.wit.core.network.model.user.request.OnboardingRequest
 import com.multissue.wit.core.network.service.UserService
 import com.multissue.wit.core.network.util.safeApiCall
@@ -16,6 +17,7 @@ import javax.inject.Inject
 
 class UserRepositoryImpl @Inject constructor(
     private val userService: UserService,
+    private val tokenProvider: TokenProvider,
     @Dispatcher(WitDispatchers.IO) private val ioDispatcher: CoroutineDispatcher,
 ) : UserRepository {
 
@@ -43,7 +45,10 @@ class UserRepositoryImpl @Inject constructor(
             profileImagePath = profileImagePath,
         )
         when (val response = safeApiCall { userService.completeOnboarding(request) }) {
-            is ApiResponse.Success -> Result.success(Unit)
+            is ApiResponse.Success -> {
+                response.data.data?.userStatus?.let { tokenProvider.saveUserStatus(it) }
+                Result.success(Unit)
+            }
             is ApiResponse.Failure -> Result.failure(
                 WitException.HttpException(response.code, response.message)
             )

--- a/core/datastore/src/main/java/com/multissue/wit/core/datastore/token/DataStoreTokenProvider.kt
+++ b/core/datastore/src/main/java/com/multissue/wit/core/datastore/token/DataStoreTokenProvider.kt
@@ -17,13 +17,22 @@ class DataStoreTokenProvider @Inject constructor(
         storage.get(WitStorageKeys.REFRESH_TOKEN)
     }
 
+    override fun getUserStatus(): String? = runBlocking {
+        storage.get(WitStorageKeys.USER_STATUS)
+    }
+
     override suspend fun saveTokens(accessToken: String, refreshToken: String) {
         storage.writeValue(WitStorageKeys.ACCESS_TOKEN, accessToken)
         storage.writeValue(WitStorageKeys.REFRESH_TOKEN, refreshToken)
     }
 
+    override suspend fun saveUserStatus(status: String) {
+        storage.writeValue(WitStorageKeys.USER_STATUS, status)
+    }
+
     override suspend fun clearTokens() {
         storage.clearValue(WitStorageKeys.ACCESS_TOKEN)
         storage.clearValue(WitStorageKeys.REFRESH_TOKEN)
+        storage.clearValue(WitStorageKeys.USER_STATUS)
     }
 }

--- a/core/datastore/src/main/java/com/multissue/wit/core/datastore/token/DataStoreTokenProvider.kt
+++ b/core/datastore/src/main/java/com/multissue/wit/core/datastore/token/DataStoreTokenProvider.kt
@@ -12,4 +12,18 @@ class DataStoreTokenProvider @Inject constructor(
     override fun getAccessToken(): String? = runBlocking {
         storage.get(WitStorageKeys.ACCESS_TOKEN)
     }
+
+    override fun getRefreshToken(): String? = runBlocking {
+        storage.get(WitStorageKeys.REFRESH_TOKEN)
+    }
+
+    override suspend fun saveTokens(accessToken: String, refreshToken: String) {
+        storage.writeValue(WitStorageKeys.ACCESS_TOKEN, accessToken)
+        storage.writeValue(WitStorageKeys.REFRESH_TOKEN, refreshToken)
+    }
+
+    override suspend fun clearTokens() {
+        storage.clearValue(WitStorageKeys.ACCESS_TOKEN)
+        storage.clearValue(WitStorageKeys.REFRESH_TOKEN)
+    }
 }

--- a/core/datastore/src/main/java/com/multissue/wit/core/datastore/token/WitStorageKeys.kt
+++ b/core/datastore/src/main/java/com/multissue/wit/core/datastore/token/WitStorageKeys.kt
@@ -5,4 +5,5 @@ import com.multissue.wit.core.datastore.storage.Storage
 object WitStorageKeys {
     val ACCESS_TOKEN = Storage.Key.StringKey("access_token", defaultValue = null)
     val REFRESH_TOKEN = Storage.Key.StringKey("refresh_token", defaultValue = null)
+    val USER_STATUS = Storage.Key.StringKey("user_status", defaultValue = null)
 }

--- a/core/designsystem/src/main/java/com/multissue/wit/designsystem/component/dialog/WitErrorDialog.kt
+++ b/core/designsystem/src/main/java/com/multissue/wit/designsystem/component/dialog/WitErrorDialog.kt
@@ -1,0 +1,77 @@
+package com.multissue.wit.designsystem.component.dialog
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.multissue.wit.designsystem.R
+import com.multissue.wit.designsystem.theme.WitTheme
+
+@Composable
+fun WitErrorDialog(
+    errorMessage: String?,
+    onDismiss: () -> Unit,
+) {
+    if (errorMessage == null) return
+
+    Dialog(onDismissRequest = onDismiss) {
+        Surface(
+            modifier = Modifier.wrapContentHeight(),
+            shape = RoundedCornerShape(12.dp),
+            color = WitTheme.colors.background,
+            shadowElevation = 2.dp
+        ) {
+            Column(
+                modifier = Modifier.padding(top = 30.dp, bottom = 20.dp, start = 20.dp, end = 20.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    text = stringResource(R.string.error_dialog_title),
+                    style = WitTheme.typography.titleL,
+                    color = WitTheme.colors.text,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                Text(
+                    text = errorMessage,
+                    style = WitTheme.typography.bodyXS,
+                    color = WitTheme.colors.subText,
+                    textAlign = TextAlign.Center,
+                )
+                Spacer(modifier = Modifier.height(26.dp))
+
+                Button(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(42.dp),
+                    shape = RoundedCornerShape(10.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = WitTheme.colors.primaryDark,
+                        contentColor = WitTheme.colors.buttonText
+                    ),
+                    onClick = onDismiss
+                ) {
+                    Text(
+                        text = stringResource(R.string.error_dialog_close),
+                        style = WitTheme.typography.titleM
+                    )
+                }
+            }
+        }
+    }
+}

--- a/core/designsystem/src/main/java/com/multissue/wit/designsystem/component/dialog/WitReLoginDialog.kt
+++ b/core/designsystem/src/main/java/com/multissue/wit/designsystem/component/dialog/WitReLoginDialog.kt
@@ -1,0 +1,77 @@
+package com.multissue.wit.designsystem.component.dialog
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import com.multissue.wit.designsystem.R
+import com.multissue.wit.designsystem.theme.WitTheme
+
+@Composable
+fun WitReLoginDialog(
+    visible: Boolean,
+    onConfirm: () -> Unit,
+) {
+    if (!visible) return
+
+    Dialog(onDismissRequest = {}) {
+        Surface(
+            modifier = Modifier.wrapContentHeight(),
+            shape = RoundedCornerShape(12.dp),
+            color = WitTheme.colors.background,
+            shadowElevation = 2.dp
+        ) {
+            Column(
+                modifier = Modifier.padding(top = 30.dp, bottom = 20.dp, start = 20.dp, end = 20.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    text = stringResource(R.string.relogin_dialog_title),
+                    style = WitTheme.typography.titleL,
+                    color = WitTheme.colors.text,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                Text(
+                    text = stringResource(R.string.relogin_dialog_message),
+                    style = WitTheme.typography.bodyXS,
+                    color = WitTheme.colors.subText,
+                    textAlign = TextAlign.Center,
+                )
+                Spacer(modifier = Modifier.height(26.dp))
+
+                Button(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(42.dp),
+                    shape = RoundedCornerShape(10.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = WitTheme.colors.primaryDark,
+                        contentColor = WitTheme.colors.buttonText
+                    ),
+                    onClick = onConfirm
+                ) {
+                    Text(
+                        text = stringResource(R.string.relogin_dialog_confirm),
+                        style = WitTheme.typography.titleM
+                    )
+                }
+            }
+        }
+    }
+}

--- a/core/designsystem/src/main/java/com/multissue/wit/designsystem/theme/WitColors.kt
+++ b/core/designsystem/src/main/java/com/multissue/wit/designsystem/theme/WitColors.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.graphics.Color
 val blue = Color(0xFF74B1FF)
 val blueDarker = Color(0xFF539FFF)
 val blueLighter = Color(0xFFD5E8FF)
+val gradientColor1 = Color(0xFFBDDAFF)
 val gradientColor2 = Color(0xFFF7FBFF)
 val gradientColor3 = Color(0xFFEFF6FF)
 val mint = Color(0xFF6BDDD2)
@@ -264,7 +265,7 @@ fun lightColorScheme(): WitColors = WitColors(
     gradientColor3 = gradientColor3,
     gradientBackground = Brush.linearGradient(
         colorStops = arrayOf(
-            0.0f to blueLighter,
+            0.0f to gradientColor1,
             0.52f to gradientColor2,
             0.96f to gradientColor3,
             1.0f to gradientColor3,

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="error_dialog_title">오류</string>
+    <string name="error_dialog_close">닫기</string>
+</resources>

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -2,4 +2,7 @@
 <resources>
     <string name="error_dialog_title">오류</string>
     <string name="error_dialog_close">닫기</string>
+    <string name="relogin_dialog_title">세션 만료</string>
+    <string name="relogin_dialog_message">로그인이 만료되었습니다. 다시 로그인해주세요.</string>
+    <string name="relogin_dialog_confirm">로그인</string>
 </resources>

--- a/core/domain/src/main/java/com/multissue/wit/core/domain/exception/WitException.kt
+++ b/core/domain/src/main/java/com/multissue/wit/core/domain/exception/WitException.kt
@@ -4,3 +4,18 @@ sealed class WitException(message: String? = null, cause: Throwable? = null) : E
     class HttpException(val code: Int, message: String?) : WitException(message)
     class NetworkException(cause: Throwable) : WitException(cause = cause)
 }
+
+fun Throwable.toUserMessage(): String = when (this) {
+    is WitException.HttpException -> message ?: defaultHttpMessage(code)
+    is WitException.NetworkException -> "네트워크 연결을 확인해주세요."
+    else -> "알 수 없는 오류가 발생했습니다."
+}
+
+private fun defaultHttpMessage(code: Int): String = when (code) {
+    400 -> "잘못된 요청입니다."
+    401 -> "로그인이 필요합니다."
+    403 -> "접근 권한이 없습니다."
+    404 -> "요청한 정보를 찾을 수 없습니다."
+    in 500..599 -> "서버에 문제가 발생했습니다. 잠시 후 다시 시도해주세요."
+    else -> "오류가 발생했습니다. (코드: $code)"
+}

--- a/core/domain/src/main/java/com/multissue/wit/core/domain/model/auth/AuthStatus.kt
+++ b/core/domain/src/main/java/com/multissue/wit/core/domain/model/auth/AuthStatus.kt
@@ -1,0 +1,11 @@
+package com.multissue.wit.core.domain.model.auth
+
+enum class AuthStatus {
+    PENDING_AGREEMENT,
+    PENDING_ONBOARDING,
+    ACTIVE,
+    INACTIVE,
+    SUSPEND,
+    WITHDRAWN,
+    DELETED,
+}

--- a/core/domain/src/main/java/com/multissue/wit/core/domain/model/auth/LoginResult.kt
+++ b/core/domain/src/main/java/com/multissue/wit/core/domain/model/auth/LoginResult.kt
@@ -2,5 +2,6 @@ package com.multissue.wit.core.domain.model.auth
 
 data class LoginResult(
     val status: AuthStatus,
-    // TODO: 서버 응답에 따라 필요한 필드 추가 (nickname, profileImagePath 등)
+    val nickname: String?,
+    val profileImagePath: String?,
 )

--- a/core/domain/src/main/java/com/multissue/wit/core/domain/model/auth/LoginResult.kt
+++ b/core/domain/src/main/java/com/multissue/wit/core/domain/model/auth/LoginResult.kt
@@ -1,0 +1,6 @@
+package com.multissue.wit.core.domain.model.auth
+
+data class LoginResult(
+    val status: AuthStatus,
+    // TODO: 서버 응답에 따라 필요한 필드 추가 (nickname, profileImagePath 등)
+)

--- a/core/domain/src/main/java/com/multissue/wit/core/domain/model/auth/SocialType.kt
+++ b/core/domain/src/main/java/com/multissue/wit/core/domain/model/auth/SocialType.kt
@@ -1,0 +1,6 @@
+package com.multissue.wit.core.domain.model.auth
+
+enum class SocialType {
+    KAKAO,
+    GOOGLE
+}

--- a/core/domain/src/main/java/com/multissue/wit/core/domain/model/terms/TermItem.kt
+++ b/core/domain/src/main/java/com/multissue/wit/core/domain/model/terms/TermItem.kt
@@ -1,0 +1,10 @@
+package com.multissue.wit.core.domain.model.terms
+
+data class TermItem(
+    val id: String,
+    val type: String,
+    val title: String,
+    val required: Boolean,
+    val version: String,
+    val contentUrl: String,
+)

--- a/core/domain/src/main/java/com/multissue/wit/core/domain/model/user/UserInfo.kt
+++ b/core/domain/src/main/java/com/multissue/wit/core/domain/model/user/UserInfo.kt
@@ -1,0 +1,9 @@
+package com.multissue.wit.core.domain.model.user
+
+data class UserInfo(
+    val nickname: String,
+    val profileImagePath: String?,
+    val age: String,
+    val gender: String,
+    val isOwner: Boolean,
+)

--- a/core/domain/src/main/java/com/multissue/wit/core/domain/repository/AuthRepository.kt
+++ b/core/domain/src/main/java/com/multissue/wit/core/domain/repository/AuthRepository.kt
@@ -1,11 +1,14 @@
 package com.multissue.wit.core.domain.repository
 
+import com.multissue.wit.core.domain.model.auth.AuthStatus
 import com.multissue.wit.core.domain.model.auth.LoginResult
 import com.multissue.wit.core.domain.model.auth.SocialType
 
 interface AuthRepository {
     suspend fun socialLogin(socialType: SocialType, token: String): Result<LoginResult>
     fun hasAccessToken(): Boolean
+    fun getUserStatus(): AuthStatus?
+    suspend fun saveUserStatus(status: AuthStatus)
     suspend fun logout(): Result<Unit>
     suspend fun clearTokens()
 }

--- a/core/domain/src/main/java/com/multissue/wit/core/domain/repository/AuthRepository.kt
+++ b/core/domain/src/main/java/com/multissue/wit/core/domain/repository/AuthRepository.kt
@@ -5,4 +5,6 @@ import com.multissue.wit.core.domain.model.auth.SocialType
 
 interface AuthRepository {
     suspend fun socialLogin(socialType: SocialType, token: String): Result<LoginResult>
+    fun hasAccessToken(): Boolean
+    suspend fun clearTokens()
 }

--- a/core/domain/src/main/java/com/multissue/wit/core/domain/repository/AuthRepository.kt
+++ b/core/domain/src/main/java/com/multissue/wit/core/domain/repository/AuthRepository.kt
@@ -1,0 +1,8 @@
+package com.multissue.wit.core.domain.repository
+
+import com.multissue.wit.core.domain.model.auth.LoginResult
+import com.multissue.wit.core.domain.model.auth.SocialType
+
+interface AuthRepository {
+    suspend fun socialLogin(socialType: SocialType, token: String): Result<LoginResult>
+}

--- a/core/domain/src/main/java/com/multissue/wit/core/domain/repository/AuthRepository.kt
+++ b/core/domain/src/main/java/com/multissue/wit/core/domain/repository/AuthRepository.kt
@@ -6,5 +6,6 @@ import com.multissue.wit.core.domain.model.auth.SocialType
 interface AuthRepository {
     suspend fun socialLogin(socialType: SocialType, token: String): Result<LoginResult>
     fun hasAccessToken(): Boolean
+    suspend fun logout(): Result<Unit>
     suspend fun clearTokens()
 }

--- a/core/domain/src/main/java/com/multissue/wit/core/domain/repository/TermsRepository.kt
+++ b/core/domain/src/main/java/com/multissue/wit/core/domain/repository/TermsRepository.kt
@@ -1,0 +1,8 @@
+package com.multissue.wit.core.domain.repository
+
+import com.multissue.wit.core.domain.model.terms.TermItem
+
+interface TermsRepository {
+    suspend fun getActiveTerms(): Result<List<TermItem>>
+    suspend fun agreeTerms(agreements: List<Pair<String, Boolean>>): Result<String>
+}

--- a/core/domain/src/main/java/com/multissue/wit/core/domain/repository/UserRepository.kt
+++ b/core/domain/src/main/java/com/multissue/wit/core/domain/repository/UserRepository.kt
@@ -2,4 +2,10 @@ package com.multissue.wit.core.domain.repository
 
 interface UserRepository {
     suspend fun checkNicknameDuplicate(nickname: String): Result<Boolean>
+    suspend fun completeOnboarding(
+        nickname: String,
+        gender: String,
+        birthDate: String,
+        profileImagePath: String?,
+    ): Result<Unit>
 }

--- a/core/domain/src/main/java/com/multissue/wit/core/domain/repository/UserRepository.kt
+++ b/core/domain/src/main/java/com/multissue/wit/core/domain/repository/UserRepository.kt
@@ -1,5 +1,7 @@
 package com.multissue.wit.core.domain.repository
 
+import com.multissue.wit.core.domain.model.user.UserInfo
+
 interface UserRepository {
     suspend fun checkNicknameDuplicate(nickname: String): Result<Boolean>
     suspend fun completeOnboarding(
@@ -8,4 +10,5 @@ interface UserRepository {
         birthDate: String,
         profileImagePath: String?,
     ): Result<Unit>
+    suspend fun getMyInfo(): Result<UserInfo>
 }

--- a/core/domain/src/main/java/com/multissue/wit/core/domain/repository/UserRepository.kt
+++ b/core/domain/src/main/java/com/multissue/wit/core/domain/repository/UserRepository.kt
@@ -1,0 +1,5 @@
+package com.multissue.wit.core.domain.repository
+
+interface UserRepository {
+    suspend fun checkNicknameDuplicate(nickname: String): Result<Boolean>
+}

--- a/core/domain/src/main/java/com/multissue/wit/core/domain/usecase/auth/AutoLoginUseCase.kt
+++ b/core/domain/src/main/java/com/multissue/wit/core/domain/usecase/auth/AutoLoginUseCase.kt
@@ -1,10 +1,12 @@
 package com.multissue.wit.core.domain.usecase.auth
 
+import com.multissue.wit.core.domain.model.auth.AuthStatus
 import com.multissue.wit.core.domain.repository.AuthRepository
 import javax.inject.Inject
 
 class AutoLoginUseCase @Inject constructor(
     private val authRepository: AuthRepository,
 ) {
-    operator fun invoke(): Boolean = authRepository.hasAccessToken()
+    operator fun invoke(): Boolean =
+        authRepository.hasAccessToken() && authRepository.getUserStatus() == AuthStatus.ACTIVE
 }

--- a/core/domain/src/main/java/com/multissue/wit/core/domain/usecase/auth/AutoLoginUseCase.kt
+++ b/core/domain/src/main/java/com/multissue/wit/core/domain/usecase/auth/AutoLoginUseCase.kt
@@ -1,0 +1,10 @@
+package com.multissue.wit.core.domain.usecase.auth
+
+import com.multissue.wit.core.domain.repository.AuthRepository
+import javax.inject.Inject
+
+class AutoLoginUseCase @Inject constructor(
+    private val authRepository: AuthRepository,
+) {
+    operator fun invoke(): Boolean = authRepository.hasAccessToken()
+}

--- a/core/domain/src/main/java/com/multissue/wit/core/domain/usecase/auth/LogoutUseCase.kt
+++ b/core/domain/src/main/java/com/multissue/wit/core/domain/usecase/auth/LogoutUseCase.kt
@@ -1,0 +1,10 @@
+package com.multissue.wit.core.domain.usecase.auth
+
+import com.multissue.wit.core.domain.repository.AuthRepository
+import javax.inject.Inject
+
+class LogoutUseCase @Inject constructor(
+    private val authRepository: AuthRepository,
+) {
+    suspend operator fun invoke(): Result<Unit> = authRepository.logout()
+}

--- a/core/domain/src/main/java/com/multissue/wit/core/domain/usecase/auth/SocialLoginUseCase.kt
+++ b/core/domain/src/main/java/com/multissue/wit/core/domain/usecase/auth/SocialLoginUseCase.kt
@@ -1,0 +1,13 @@
+package com.multissue.wit.core.domain.usecase.auth
+
+import com.multissue.wit.core.domain.model.auth.LoginResult
+import com.multissue.wit.core.domain.model.auth.SocialType
+import com.multissue.wit.core.domain.repository.AuthRepository
+import javax.inject.Inject
+
+class SocialLoginUseCase @Inject constructor(
+    private val authRepository: AuthRepository,
+) {
+    suspend operator fun invoke(socialType: SocialType, token: String): Result<LoginResult> =
+        authRepository.socialLogin(socialType, token)
+}

--- a/core/domain/src/main/java/com/multissue/wit/core/domain/usecase/terms/AgreeTermsUseCase.kt
+++ b/core/domain/src/main/java/com/multissue/wit/core/domain/usecase/terms/AgreeTermsUseCase.kt
@@ -1,0 +1,11 @@
+package com.multissue.wit.core.domain.usecase.terms
+
+import com.multissue.wit.core.domain.repository.TermsRepository
+import javax.inject.Inject
+
+class AgreeTermsUseCase @Inject constructor(
+    private val termsRepository: TermsRepository,
+) {
+    suspend operator fun invoke(agreements: List<Pair<String, Boolean>>): Result<String> =
+        termsRepository.agreeTerms(agreements)
+}

--- a/core/domain/src/main/java/com/multissue/wit/core/domain/usecase/terms/GetActiveTermsUseCase.kt
+++ b/core/domain/src/main/java/com/multissue/wit/core/domain/usecase/terms/GetActiveTermsUseCase.kt
@@ -1,0 +1,12 @@
+package com.multissue.wit.core.domain.usecase.terms
+
+import com.multissue.wit.core.domain.model.terms.TermItem
+import com.multissue.wit.core.domain.repository.TermsRepository
+import javax.inject.Inject
+
+class GetActiveTermsUseCase @Inject constructor(
+    private val termsRepository: TermsRepository,
+) {
+    suspend operator fun invoke(): Result<List<TermItem>> =
+        termsRepository.getActiveTerms()
+}

--- a/core/domain/src/main/java/com/multissue/wit/core/domain/usecase/user/CheckNicknameDuplicateUseCase.kt
+++ b/core/domain/src/main/java/com/multissue/wit/core/domain/usecase/user/CheckNicknameDuplicateUseCase.kt
@@ -1,0 +1,11 @@
+package com.multissue.wit.core.domain.usecase.user
+
+import com.multissue.wit.core.domain.repository.UserRepository
+import javax.inject.Inject
+
+class CheckNicknameDuplicateUseCase @Inject constructor(
+    private val userRepository: UserRepository,
+) {
+    suspend operator fun invoke(nickname: String): Result<Boolean> =
+        userRepository.checkNicknameDuplicate(nickname)
+}

--- a/core/domain/src/main/java/com/multissue/wit/core/domain/usecase/user/CompleteOnboardingUseCase.kt
+++ b/core/domain/src/main/java/com/multissue/wit/core/domain/usecase/user/CompleteOnboardingUseCase.kt
@@ -1,0 +1,20 @@
+package com.multissue.wit.core.domain.usecase.user
+
+import com.multissue.wit.core.domain.repository.UserRepository
+import javax.inject.Inject
+
+class CompleteOnboardingUseCase @Inject constructor(
+    private val userRepository: UserRepository,
+) {
+    suspend operator fun invoke(
+        nickname: String,
+        gender: String,
+        birthDate: String,
+        profileImagePath: String? = null,
+    ): Result<Unit> = userRepository.completeOnboarding(
+        nickname = nickname,
+        gender = gender,
+        birthDate = birthDate,
+        profileImagePath = profileImagePath,
+    )
+}

--- a/core/domain/src/main/java/com/multissue/wit/core/domain/usecase/user/GetMyInfoUseCase.kt
+++ b/core/domain/src/main/java/com/multissue/wit/core/domain/usecase/user/GetMyInfoUseCase.kt
@@ -1,0 +1,11 @@
+package com.multissue.wit.core.domain.usecase.user
+
+import com.multissue.wit.core.domain.model.user.UserInfo
+import com.multissue.wit.core.domain.repository.UserRepository
+import javax.inject.Inject
+
+class GetMyInfoUseCase @Inject constructor(
+    private val userRepository: UserRepository,
+) {
+    suspend operator fun invoke(): Result<UserInfo> = userRepository.getMyInfo()
+}

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -6,3 +6,7 @@ plugins {
 android {
     namespace = "com.multissue.wit.core.network"
 }
+
+dependencies {
+    implementation(libs.kotlinx.serialization.json)
+}

--- a/core/network/src/main/java/com/multissue/wit/core/network/auth/AuthEventBus.kt
+++ b/core/network/src/main/java/com/multissue/wit/core/network/auth/AuthEventBus.kt
@@ -1,0 +1,21 @@
+package com.multissue.wit.core.network.auth
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AuthEventBus @Inject constructor() {
+
+    private val _events = MutableSharedFlow<AuthEvent>(extraBufferCapacity = 1)
+    val events: SharedFlow<AuthEvent> = _events
+
+    fun emit(event: AuthEvent) {
+        _events.tryEmit(event)
+    }
+}
+
+sealed interface AuthEvent {
+    data object TokenExpired : AuthEvent
+}

--- a/core/network/src/main/java/com/multissue/wit/core/network/di/AuthNetworkModule.kt
+++ b/core/network/src/main/java/com/multissue/wit/core/network/di/AuthNetworkModule.kt
@@ -1,0 +1,19 @@
+package com.multissue.wit.core.network.di
+
+import com.multissue.wit.core.network.service.AuthService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AuthNetworkModule {
+
+    @Provides
+    @Singleton
+    fun provideAuthService(retrofit: Retrofit): AuthService =
+        retrofit.create(AuthService::class.java)
+}

--- a/core/network/src/main/java/com/multissue/wit/core/network/di/AuthNetworkModule.kt
+++ b/core/network/src/main/java/com/multissue/wit/core/network/di/AuthNetworkModule.kt
@@ -16,4 +16,10 @@ object AuthNetworkModule {
     @Singleton
     fun provideAuthService(retrofit: Retrofit): AuthService =
         retrofit.create(AuthService::class.java)
+
+    @Provides
+    @Singleton
+    @TokenRefresh
+    fun provideTokenRefreshAuthService(@TokenRefresh retrofit: Retrofit): AuthService =
+        retrofit.create(AuthService::class.java)
 }

--- a/core/network/src/main/java/com/multissue/wit/core/network/di/NetworkModule.kt
+++ b/core/network/src/main/java/com/multissue/wit/core/network/di/NetworkModule.kt
@@ -1,7 +1,12 @@
 package com.multissue.wit.core.network.di
 
+import com.multissue.wit.core.network.auth.AuthEventBus
 import com.multissue.wit.core.network.config.NetworkConfig
 import com.multissue.wit.core.network.interceptor.AuthInterceptor
+import com.multissue.wit.core.network.interceptor.PrettyJsonLogger
+import com.multissue.wit.core.network.interceptor.TokenAuthenticator
+import com.multissue.wit.core.network.interceptor.TokenProvider
+import com.multissue.wit.core.network.service.AuthService
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -24,6 +29,7 @@ object NetworkModule {
         ignoreUnknownKeys = true
         coerceInputValues = true
         isLenient = true
+        prettyPrint = true
     }
 
     @Provides
@@ -31,7 +37,7 @@ object NetworkModule {
     fun provideHttpLoggingInterceptor(
         networkConfig: NetworkConfig,
     ): HttpLoggingInterceptor =
-        HttpLoggingInterceptor().apply {
+        HttpLoggingInterceptor(PrettyJsonLogger()).apply {
             level = if (networkConfig.isDebug) {
                 HttpLoggingInterceptor.Level.BODY
             } else {
@@ -41,12 +47,48 @@ object NetworkModule {
 
     @Provides
     @Singleton
+    @TokenRefresh
+    fun provideTokenRefreshOkHttpClient(
+        loggingInterceptor: HttpLoggingInterceptor,
+    ): OkHttpClient = OkHttpClient.Builder()
+        .addInterceptor(loggingInterceptor)
+        .build()
+
+    @Provides
+    @Singleton
+    @TokenRefresh
+    fun provideTokenRefreshRetrofit(
+        @TokenRefresh okHttpClient: OkHttpClient,
+        json: Json,
+        networkConfig: NetworkConfig,
+    ): Retrofit = Retrofit.Builder()
+        .baseUrl(networkConfig.baseUrl)
+        .client(okHttpClient)
+        .addConverterFactory(json.asConverterFactory("application/json; charset=UTF-8".toMediaType()))
+        .build()
+
+    @Provides
+    @Singleton
+    fun provideTokenAuthenticator(
+        tokenProvider: TokenProvider,
+        @TokenRefresh authService: AuthService,
+        authEventBus: AuthEventBus,
+    ): TokenAuthenticator = TokenAuthenticator(
+        tokenProvider = tokenProvider,
+        authService = authService,
+        authEventBus = authEventBus,
+    )
+
+    @Provides
+    @Singleton
     fun provideOkHttpClient(
         loggingInterceptor: HttpLoggingInterceptor,
         authInterceptor: AuthInterceptor,
+        tokenAuthenticator: TokenAuthenticator,
     ): OkHttpClient = OkHttpClient.Builder()
         .addInterceptor(authInterceptor)
         .addInterceptor(loggingInterceptor)
+        .authenticator(tokenAuthenticator)
         .build()
 
     @Provides

--- a/core/network/src/main/java/com/multissue/wit/core/network/di/TermsNetworkModule.kt
+++ b/core/network/src/main/java/com/multissue/wit/core/network/di/TermsNetworkModule.kt
@@ -1,0 +1,19 @@
+package com.multissue.wit.core.network.di
+
+import com.multissue.wit.core.network.service.TermsService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object TermsNetworkModule {
+
+    @Provides
+    @Singleton
+    fun provideTermsService(retrofit: Retrofit): TermsService =
+        retrofit.create(TermsService::class.java)
+}

--- a/core/network/src/main/java/com/multissue/wit/core/network/di/TokenRefresh.kt
+++ b/core/network/src/main/java/com/multissue/wit/core/network/di/TokenRefresh.kt
@@ -1,0 +1,7 @@
+package com.multissue.wit.core.network.di
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class TokenRefresh

--- a/core/network/src/main/java/com/multissue/wit/core/network/di/UserNetworkModule.kt
+++ b/core/network/src/main/java/com/multissue/wit/core/network/di/UserNetworkModule.kt
@@ -1,0 +1,19 @@
+package com.multissue.wit.core.network.di
+
+import com.multissue.wit.core.network.service.UserService
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object UserNetworkModule {
+
+    @Provides
+    @Singleton
+    fun provideUserService(retrofit: Retrofit): UserService =
+        retrofit.create(UserService::class.java)
+}

--- a/core/network/src/main/java/com/multissue/wit/core/network/interceptor/AuthInterceptor.kt
+++ b/core/network/src/main/java/com/multissue/wit/core/network/interceptor/AuthInterceptor.kt
@@ -1,5 +1,7 @@
 package com.multissue.wit.core.network.interceptor
 
+import com.multissue.wit.core.network.interceptor.Constant.AUTHORIZATION
+import com.multissue.wit.core.network.interceptor.Constant.BEARER_PREFIX
 import okhttp3.Interceptor
 import okhttp3.Response
 import javax.inject.Inject
@@ -12,7 +14,7 @@ class AuthInterceptor @Inject constructor(
         val token = tokenProvider.getAccessToken()
         val request = if (token != null) {
             chain.request().newBuilder()
-                .header("Authorization", "Bearer $token")
+                .header(AUTHORIZATION, "$BEARER_PREFIX $token")
                 .build()
         } else {
             chain.request()

--- a/core/network/src/main/java/com/multissue/wit/core/network/interceptor/Constant.kt
+++ b/core/network/src/main/java/com/multissue/wit/core/network/interceptor/Constant.kt
@@ -1,0 +1,7 @@
+package com.multissue.wit.core.network.interceptor
+
+object Constant {
+    const val AUTHORIZATION = "Authorization"
+    const val BEARER_PREFIX = "Bearer"
+    const val HEADER_RETRY = "X-Token-Retry"
+}

--- a/core/network/src/main/java/com/multissue/wit/core/network/interceptor/PrettyJsonLogger.kt
+++ b/core/network/src/main/java/com/multissue/wit/core/network/interceptor/PrettyJsonLogger.kt
@@ -1,0 +1,27 @@
+package com.multissue.wit.core.network.interceptor
+
+import android.util.Log
+import okhttp3.logging.HttpLoggingInterceptor
+import org.json.JSONArray
+import org.json.JSONObject
+
+class PrettyJsonLogger : HttpLoggingInterceptor.Logger {
+
+    override fun log(message: String) {
+        if (message.startsWith("{") || message.startsWith("[")) {
+            try {
+                val pretty = when {
+                    message.startsWith("{") -> JSONObject(message).toString(2)
+                    else -> JSONArray(message).toString(2)
+                }
+                Log.d(TAG, pretty)
+                return
+            } catch (_: Exception) { }
+        }
+        Log.d(TAG, message)
+    }
+
+    companion object {
+        private const val TAG = "WitHttp"
+    }
+}

--- a/core/network/src/main/java/com/multissue/wit/core/network/interceptor/TokenAuthenticator.kt
+++ b/core/network/src/main/java/com/multissue/wit/core/network/interceptor/TokenAuthenticator.kt
@@ -1,0 +1,76 @@
+package com.multissue.wit.core.network.interceptor
+
+import com.multissue.wit.core.network.auth.AuthEvent
+import com.multissue.wit.core.network.auth.AuthEventBus
+import com.multissue.wit.core.network.interceptor.Constant.AUTHORIZATION
+import com.multissue.wit.core.network.interceptor.Constant.BEARER_PREFIX
+import com.multissue.wit.core.network.interceptor.Constant.HEADER_RETRY
+import com.multissue.wit.core.network.model.auth.request.RefreshTokenRequest
+import com.multissue.wit.core.network.service.AuthService
+import kotlinx.coroutines.runBlocking
+import okhttp3.Authenticator
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.Route
+
+class TokenAuthenticator(
+    private val tokenProvider: TokenProvider,
+    private val authService: AuthService,
+    private val authEventBus: AuthEventBus,
+) : Authenticator {
+
+    override fun authenticate(route: Route?, response: Response): Request? {
+        // 이미 refresh 시도 후 실패한 경우 무한 루프 방지
+        if (response.request.header(HEADER_RETRY) != null) {
+            runBlocking { tokenProvider.clearTokens() }
+            authEventBus.emit(AuthEvent.TokenExpired)
+            return null
+        }
+
+        val refreshToken = tokenProvider.getRefreshToken() ?: run {
+            runBlocking { tokenProvider.clearTokens() }
+            authEventBus.emit(AuthEvent.TokenExpired)
+            return null
+        }
+
+        return synchronized(this) {
+            // 다른 스레드에서 이미 갱신했는지 확인
+            val currentToken = tokenProvider.getAccessToken()
+            val requestToken = response.request.header(AUTHORIZATION)?.removePrefix("$BEARER_PREFIX ")
+
+            if (currentToken != null && currentToken != requestToken) {
+                // 이미 다른 스레드에서 갱신됨 → 새 토큰으로 재시도
+                return@synchronized response.request.newBuilder()
+                    .header(AUTHORIZATION, "$BEARER_PREFIX $currentToken")
+                    .header(HEADER_RETRY, "true")
+                    .build()
+            }
+
+            // Refresh Token으로 갱신 시도
+            val newTokens = try {
+                runBlocking {
+                    authService.refreshToken(RefreshTokenRequest(refreshToken))
+                }
+            } catch (_: Exception) {
+                runBlocking { tokenProvider.clearTokens() }
+                authEventBus.emit(AuthEvent.TokenExpired)
+                return@synchronized null
+            }
+
+            val data = newTokens.data ?: run {
+                runBlocking { tokenProvider.clearTokens() }
+                authEventBus.emit(AuthEvent.TokenExpired)
+                return@synchronized null
+            }
+
+            runBlocking {
+                tokenProvider.saveTokens(data.accessToken, data.refreshToken)
+            }
+
+            response.request.newBuilder()
+                .header(AUTHORIZATION, "$BEARER_PREFIX ${data.accessToken}")
+                .header(HEADER_RETRY, "true")
+                .build()
+        }
+    }
+}

--- a/core/network/src/main/java/com/multissue/wit/core/network/interceptor/TokenProvider.kt
+++ b/core/network/src/main/java/com/multissue/wit/core/network/interceptor/TokenProvider.kt
@@ -3,6 +3,8 @@ package com.multissue.wit.core.network.interceptor
 interface TokenProvider {
     fun getAccessToken(): String?
     fun getRefreshToken(): String?
+    fun getUserStatus(): String?
     suspend fun saveTokens(accessToken: String, refreshToken: String)
+    suspend fun saveUserStatus(status: String)
     suspend fun clearTokens()
 }

--- a/core/network/src/main/java/com/multissue/wit/core/network/interceptor/TokenProvider.kt
+++ b/core/network/src/main/java/com/multissue/wit/core/network/interceptor/TokenProvider.kt
@@ -2,4 +2,7 @@ package com.multissue.wit.core.network.interceptor
 
 interface TokenProvider {
     fun getAccessToken(): String?
+    fun getRefreshToken(): String?
+    suspend fun saveTokens(accessToken: String, refreshToken: String)
+    suspend fun clearTokens()
 }

--- a/core/network/src/main/java/com/multissue/wit/core/network/model/BaseResponse.kt
+++ b/core/network/src/main/java/com/multissue/wit/core/network/model/BaseResponse.kt
@@ -1,0 +1,11 @@
+package com.multissue.wit.core.network.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class BaseResponse<T>(
+    val success: Boolean,
+    val status: Int,
+    val data: T,
+    val timestamp: String,
+)

--- a/core/network/src/main/java/com/multissue/wit/core/network/model/BaseResponse.kt
+++ b/core/network/src/main/java/com/multissue/wit/core/network/model/BaseResponse.kt
@@ -9,3 +9,9 @@ data class BaseResponse<T>(
     val data: T? = null,
     val timestamp: String,
 )
+
+@Serializable
+data class ErrorData(
+    val code: String,
+    val message: String,
+)

--- a/core/network/src/main/java/com/multissue/wit/core/network/model/BaseResponse.kt
+++ b/core/network/src/main/java/com/multissue/wit/core/network/model/BaseResponse.kt
@@ -6,6 +6,6 @@ import kotlinx.serialization.Serializable
 data class BaseResponse<T>(
     val success: Boolean,
     val status: Int,
-    val data: T,
+    val data: T? = null,
     val timestamp: String,
 )

--- a/core/network/src/main/java/com/multissue/wit/core/network/model/auth/request/RefreshTokenRequest.kt
+++ b/core/network/src/main/java/com/multissue/wit/core/network/model/auth/request/RefreshTokenRequest.kt
@@ -1,0 +1,8 @@
+package com.multissue.wit.core.network.model.auth.request
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RefreshTokenRequest(
+    val refreshToken: String,
+)

--- a/core/network/src/main/java/com/multissue/wit/core/network/model/auth/request/SocialLoginRequest.kt
+++ b/core/network/src/main/java/com/multissue/wit/core/network/model/auth/request/SocialLoginRequest.kt
@@ -1,0 +1,9 @@
+package com.multissue.wit.core.network.model.auth.request
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SocialLoginRequest(
+    val socialType: String,
+    val token: String,
+)

--- a/core/network/src/main/java/com/multissue/wit/core/network/model/auth/response/RefreshTokenResponse.kt
+++ b/core/network/src/main/java/com/multissue/wit/core/network/model/auth/response/RefreshTokenResponse.kt
@@ -1,0 +1,11 @@
+package com.multissue.wit.core.network.model.auth.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RefreshTokenResponse(
+    val accessToken: String,
+    val accessTokenExpiresAt: Long,
+    val refreshToken: String,
+    val refreshTokenExpiresAt: Long,
+)

--- a/core/network/src/main/java/com/multissue/wit/core/network/model/auth/response/SocialLoginResponse.kt
+++ b/core/network/src/main/java/com/multissue/wit/core/network/model/auth/response/SocialLoginResponse.kt
@@ -1,0 +1,14 @@
+package com.multissue.wit.core.network.model.auth.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SocialLoginResponse(
+    val accessToken: String,
+    val accessTokenExpiresAt: Long,
+    val refreshToken: String,
+    val refreshTokenExpiresAt: Long,
+    val status: String,
+    val nickname: String? = null,
+    val profileImagePath: String? = null,
+)

--- a/core/network/src/main/java/com/multissue/wit/core/network/model/terms/request/AgreeTermsRequest.kt
+++ b/core/network/src/main/java/com/multissue/wit/core/network/model/terms/request/AgreeTermsRequest.kt
@@ -1,0 +1,14 @@
+package com.multissue.wit.core.network.model.terms.request
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AgreeTermsRequest(
+    val terms: List<TermAgreement>,
+)
+
+@Serializable
+data class TermAgreement(
+    val termId: String,
+    val agreed: Boolean,
+)

--- a/core/network/src/main/java/com/multissue/wit/core/network/model/terms/response/AgreeTermsResponse.kt
+++ b/core/network/src/main/java/com/multissue/wit/core/network/model/terms/response/AgreeTermsResponse.kt
@@ -1,0 +1,8 @@
+package com.multissue.wit.core.network.model.terms.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AgreeTermsResponse(
+    val userStatus: String,
+)

--- a/core/network/src/main/java/com/multissue/wit/core/network/model/terms/response/TermsListResponse.kt
+++ b/core/network/src/main/java/com/multissue/wit/core/network/model/terms/response/TermsListResponse.kt
@@ -1,0 +1,18 @@
+package com.multissue.wit.core.network.model.terms.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TermsListResponse(
+    val terms: List<TermItemResponse>,
+)
+
+@Serializable
+data class TermItemResponse(
+    val id: String,
+    val type: String,
+    val title: String,
+    val required: Boolean,
+    val version: String,
+    val contentUrl: String,
+)

--- a/core/network/src/main/java/com/multissue/wit/core/network/model/user/request/OnboardingRequest.kt
+++ b/core/network/src/main/java/com/multissue/wit/core/network/model/user/request/OnboardingRequest.kt
@@ -1,0 +1,11 @@
+package com.multissue.wit.core.network.model.user.request
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class OnboardingRequest(
+    val nickname: String,
+    val gender: String,
+    val birthDate: String,
+    val profileImagePath: String? = null,
+)

--- a/core/network/src/main/java/com/multissue/wit/core/network/model/user/response/OnboardingResponse.kt
+++ b/core/network/src/main/java/com/multissue/wit/core/network/model/user/response/OnboardingResponse.kt
@@ -1,0 +1,10 @@
+package com.multissue.wit.core.network.model.user.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class OnboardingResponse(
+    val userStatus: String,
+    val nickname: String,
+    val profileImagePath: String? = null,
+)

--- a/core/network/src/main/java/com/multissue/wit/core/network/model/user/response/UserInfoResponse.kt
+++ b/core/network/src/main/java/com/multissue/wit/core/network/model/user/response/UserInfoResponse.kt
@@ -1,0 +1,12 @@
+package com.multissue.wit.core.network.model.user.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class UserInfoResponse(
+    val nickname: String,
+    val profileImagePath: String?,
+    val age: String,
+    val gender: String,
+    val isOwner: Boolean,
+)

--- a/core/network/src/main/java/com/multissue/wit/core/network/service/AuthService.kt
+++ b/core/network/src/main/java/com/multissue/wit/core/network/service/AuthService.kt
@@ -1,0 +1,25 @@
+package com.multissue.wit.core.network.service
+
+import com.multissue.wit.core.network.model.BaseResponse
+import com.multissue.wit.core.network.model.auth.request.RefreshTokenRequest
+import com.multissue.wit.core.network.model.auth.request.SocialLoginRequest
+import com.multissue.wit.core.network.model.auth.response.RefreshTokenResponse
+import com.multissue.wit.core.network.model.auth.response.SocialLoginResponse
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface AuthService {
+
+    @POST("v1/auth/login/social")
+    suspend fun socialLogin(
+        @Body request: SocialLoginRequest,
+    ): BaseResponse<SocialLoginResponse>
+
+    @POST("v1/auth/refresh")
+    suspend fun refreshToken(
+        @Body request: RefreshTokenRequest,
+    ): BaseResponse<RefreshTokenResponse>
+
+    @POST("v1/auth/logout")
+    suspend fun logout()
+}

--- a/core/network/src/main/java/com/multissue/wit/core/network/service/TermsService.kt
+++ b/core/network/src/main/java/com/multissue/wit/core/network/service/TermsService.kt
@@ -1,0 +1,20 @@
+package com.multissue.wit.core.network.service
+
+import com.multissue.wit.core.network.model.BaseResponse
+import com.multissue.wit.core.network.model.terms.request.AgreeTermsRequest
+import com.multissue.wit.core.network.model.terms.response.AgreeTermsResponse
+import com.multissue.wit.core.network.model.terms.response.TermsListResponse
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+
+interface TermsService {
+
+    @GET("v1/terms/active")
+    suspend fun getActiveTerms(): BaseResponse<TermsListResponse>
+
+    @POST("v1/users/terms")
+    suspend fun agreeTerms(
+        @Body request: AgreeTermsRequest,
+    ): BaseResponse<AgreeTermsResponse>
+}

--- a/core/network/src/main/java/com/multissue/wit/core/network/service/UserService.kt
+++ b/core/network/src/main/java/com/multissue/wit/core/network/service/UserService.kt
@@ -3,6 +3,7 @@ package com.multissue.wit.core.network.service
 import com.multissue.wit.core.network.model.BaseResponse
 import com.multissue.wit.core.network.model.user.request.OnboardingRequest
 import com.multissue.wit.core.network.model.user.response.OnboardingResponse
+import com.multissue.wit.core.network.model.user.response.UserInfoResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.PATCH
@@ -19,4 +20,7 @@ interface UserService {
     suspend fun completeOnboarding(
         @Body request: OnboardingRequest,
     ): BaseResponse<OnboardingResponse>
+
+    @GET("v1/users/me")
+    suspend fun getMyInfo(): BaseResponse<UserInfoResponse>
 }

--- a/core/network/src/main/java/com/multissue/wit/core/network/service/UserService.kt
+++ b/core/network/src/main/java/com/multissue/wit/core/network/service/UserService.kt
@@ -1,6 +1,11 @@
 package com.multissue.wit.core.network.service
 
+import com.multissue.wit.core.network.model.BaseResponse
+import com.multissue.wit.core.network.model.user.request.OnboardingRequest
+import com.multissue.wit.core.network.model.user.response.OnboardingResponse
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.PATCH
 import retrofit2.http.Query
 
 interface UserService {
@@ -9,4 +14,9 @@ interface UserService {
     suspend fun checkNicknameDuplicate(
         @Query("value") nickname: String,
     )
+
+    @PATCH("v1/users/onboarding")
+    suspend fun completeOnboarding(
+        @Body request: OnboardingRequest,
+    ): BaseResponse<OnboardingResponse>
 }

--- a/core/network/src/main/java/com/multissue/wit/core/network/service/UserService.kt
+++ b/core/network/src/main/java/com/multissue/wit/core/network/service/UserService.kt
@@ -1,0 +1,12 @@
+package com.multissue.wit.core.network.service
+
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface UserService {
+
+    @GET("v1/users/check/nickname")
+    suspend fun checkNicknameDuplicate(
+        @Query("value") nickname: String,
+    )
+}

--- a/core/network/src/main/java/com/multissue/wit/core/network/util/NetworkExt.kt
+++ b/core/network/src/main/java/com/multissue/wit/core/network/util/NetworkExt.kt
@@ -1,18 +1,31 @@
 package com.multissue.wit.core.network.util
 
 import com.multissue.wit.core.network.model.ApiResponse
+import com.multissue.wit.core.network.model.ErrorData
+import com.multissue.wit.core.network.model.BaseResponse
 import kotlinx.coroutines.CancellationException
+import kotlinx.serialization.json.Json
 import retrofit2.HttpException
 import java.io.IOException
+
+private val errorJson = Json { ignoreUnknownKeys = true }
 
 suspend fun <T> safeApiCall(apiCall: suspend () -> T): ApiResponse<T> = try {
     ApiResponse.Success(apiCall())
 } catch (e: CancellationException) {
     throw e
 } catch (e: HttpException) {
-    ApiResponse.Failure(e.code(), e.message())
+    ApiResponse.Failure(e.code(), e.parseServerMessage())
 } catch (e: IOException) {
     ApiResponse.NetworkError(e)
 } catch (e: Exception) {
     ApiResponse.NetworkError(e)
+}
+
+private fun HttpException.parseServerMessage(): String? = try {
+    response()?.errorBody()?.string()?.let { body ->
+        errorJson.decodeFromString<BaseResponse<ErrorData>>(body).data?.message
+    }
+} catch (_: Exception) {
+    message()
 }

--- a/feature/login/build.gradle.kts
+++ b/feature/login/build.gradle.kts
@@ -1,7 +1,27 @@
+import java.util.Properties
+
 android.namespace = "com.multissue.wit.feature.login"
 
 plugins {
     alias(libs.plugins.com.multissue.wit.feature)
+}
+
+val localProperties = Properties().apply {
+    val file = rootProject.file("local.properties")
+    if (file.exists()) load(file.inputStream())
+}
+
+android {
+    buildFeatures {
+        buildConfig = true
+    }
+    defaultConfig {
+        buildConfigField(
+            "String",
+            "GOOGLE_CLIENT_ID",
+            "\"${localProperties.getProperty("GOOGLE_CLIENT_ID", "")}\""
+        )
+    }
 }
 
 kotlin {
@@ -10,6 +30,9 @@ kotlin {
             implementation(libs.androidx.compose.material3)
             implementation(projects.core.domain)
             implementation(libs.kakao.user)
+            implementation(libs.credentials)
+            implementation(libs.credentials.play.services)
+            implementation(libs.googleid)
         }
     }
 }

--- a/feature/login/build.gradle.kts
+++ b/feature/login/build.gradle.kts
@@ -8,6 +8,8 @@ kotlin {
     sourceSets {
         dependencies {
             implementation(libs.androidx.compose.material3)
+            implementation(projects.core.domain)
+            implementation(libs.kakao.user)
         }
     }
 }

--- a/feature/login/src/main/java/com/multissue/wit/feature/login/LoginScreen.kt
+++ b/feature/login/src/main/java/com/multissue/wit/feature/login/LoginScreen.kt
@@ -26,7 +26,9 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.credentials.exceptions.GetCredentialCancellationException
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import com.multissue.wit.core.domain.model.auth.AuthStatus
 import com.multissue.wit.designsystem.component.background.WitGradientBackground
 import com.multissue.wit.designsystem.theme.WitTheme
 import com.multissue.wit.designsystem.theme.white100
@@ -49,7 +51,10 @@ internal fun LoginScreen(
         viewModel.sideEffect.collect { effect ->
             when (effect) {
                 is LoginSideEffect.LoginSuccess -> {
-                    // TODO: status에 따른 분기 처리 (ACTIVE → Main, 그 외 → SignUp 등)
+                    when (effect.status) {
+                        AuthStatus.ACTIVE -> navigateToMain()
+                        else -> navigateToSignUp()
+                    }
                 }
                 is LoginSideEffect.LoginError -> {
                     Log.e("LoginScreen", effect.message)
@@ -64,6 +69,9 @@ internal fun LoginScreen(
         onKakaoLogin = { token ->
             viewModel.onIntent(LoginUiIntent.KakaoLoginClicked(token))
         },
+        onGoogleLogin = { token ->
+            viewModel.onIntent(LoginUiIntent.GoogleLoginClicked(token))
+        },
     )
 }
 
@@ -71,6 +79,7 @@ internal fun LoginScreen(
 private fun LoginScreen(
     isLoading: Boolean,
     onKakaoLogin: (String) -> Unit,
+    onGoogleLogin: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val scope = rememberCoroutineScope()
@@ -87,11 +96,11 @@ private fun LoginScreen(
             Spacer(modifier = Modifier.height(80.dp))
 
             Text(
-                text = "혼자일 때보다 안전하게",
+                text = stringResource(R.string.login_title_first),
                 style = WitTheme.typography.titleXXL
             )
             Text(
-                text = "함께라서 더 즐겁게!",
+                text = stringResource(R.string.login_title_second),
                 style = WitTheme.typography.titleXXL
             )
 
@@ -138,7 +147,6 @@ private fun LoginScreen(
 
             Spacer(modifier = Modifier.height(12.dp))
 
-            // TODO: Google 로그인 버튼 추가
             SocialLoginButton(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -158,7 +166,16 @@ private fun LoginScreen(
                     contentColor = WitTheme.colors.text
                 )
             ) {
-                // TODO: Google 로그인 구현
+                if (!isLoading) {
+                    scope.launch {
+                        runCatching { SocialLoginClient.loginWithGoogle(context) }
+                            .onSuccess(onGoogleLogin)
+                            .onFailure {
+                                if (it is GetCredentialCancellationException) return@launch
+                                Log.e("LoginScreen", "구글 로그인 실패", it)
+                            }
+                    }
+                }
             }
 
             Spacer(modifier = Modifier.height(26.dp))

--- a/feature/login/src/main/java/com/multissue/wit/feature/login/LoginScreen.kt
+++ b/feature/login/src/main/java/com/multissue/wit/feature/login/LoginScreen.kt
@@ -1,5 +1,6 @@
 package com.multissue.wit.feature.login
 
+import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -11,24 +12,70 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.multissue.wit.designsystem.component.background.WitGradientBackground
 import com.multissue.wit.designsystem.theme.WitTheme
 import com.multissue.wit.designsystem.theme.white100
 import com.multissue.wit.designsystem.theme.yellow
 import com.multissue.wit.feature.login.component.SocialLoginButton
+import com.multissue.wit.feature.login.social.SocialLoginClient
+import com.multissue.wit.feature.login.state.LoginSideEffect
+import com.multissue.wit.feature.login.state.LoginUiIntent
+import kotlinx.coroutines.launch
 
 @Composable
 internal fun LoginScreen(
-    modifier: Modifier = Modifier,
+    viewModel: LoginViewModel = hiltViewModel(),
     navigateToSignUp: () -> Unit,
+    navigateToMain: () -> Unit,
 ) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.sideEffect.collect { effect ->
+            when (effect) {
+                is LoginSideEffect.LoginSuccess -> {
+                    // TODO: status에 따른 분기 처리 (ACTIVE → Main, 그 외 → SignUp 등)
+                }
+                is LoginSideEffect.LoginError -> {
+                    Log.e("LoginScreen", effect.message)
+                    // TODO: 에러 UI 표시 (Snackbar 등)
+                }
+            }
+        }
+    }
+
+    LoginScreen(
+        isLoading = uiState.isLoading,
+        onKakaoLogin = { token ->
+            viewModel.onIntent(LoginUiIntent.KakaoLoginClicked(token))
+        },
+    )
+}
+
+@Composable
+private fun LoginScreen(
+    isLoading: Boolean,
+    onKakaoLogin: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val scope = rememberCoroutineScope()
+    val context = LocalContext.current
+
     WitGradientBackground {
         Column(
             modifier = modifier
@@ -36,19 +83,30 @@ internal fun LoginScreen(
                 .statusBarsPadding()
                 .navigationBarsPadding()
                 .padding(horizontal = 26.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            Spacer(modifier = Modifier.weight(1f))
+            Spacer(modifier = Modifier.height(80.dp))
+
+            Text(
+                text = "혼자일 때보다 안전하게",
+                style = WitTheme.typography.titleXXL
+            )
+            Text(
+                text = "함께라서 더 즐겁게!",
+                style = WitTheme.typography.titleXXL
+            )
+
+            Spacer(modifier = Modifier.height(183.dp))
 
             Image(
                 modifier = Modifier
-                    .width(200.dp)
-                    .height(146.dp),
+                    .width(95.dp)
+                    .wrapContentHeight()
+                    .align(Alignment.CenterHorizontally),
                 painter = painterResource(R.drawable.image_login_logo),
                 contentDescription = "지구 이미지"
             )
 
-            Spacer(modifier = Modifier.height(156.dp))
+            Spacer(modifier = Modifier.weight(1f))
 
             SocialLoginButton(
                 modifier = Modifier
@@ -69,12 +127,18 @@ internal fun LoginScreen(
                     contentColor = WitTheme.colors.text
                 )
             ) {
-                navigateToSignUp()
-                // TODO("카카오 로그인")
+                if (!isLoading) {
+                    scope.launch {
+                        runCatching { SocialLoginClient.loginWithKakao(context) }
+                            .onSuccess(onKakaoLogin)
+                            .onFailure { Log.e("LoginScreen", "카카오 로그인 실패", it) }
+                    }
+                }
             }
 
             Spacer(modifier = Modifier.height(12.dp))
 
+            // TODO: Google 로그인 버튼 추가
             SocialLoginButton(
                 modifier = Modifier
                     .fillMaxWidth()
@@ -94,10 +158,9 @@ internal fun LoginScreen(
                     contentColor = WitTheme.colors.text
                 )
             ) {
-                navigateToSignUp()
-                // TODO("구글 로그인")
+                // TODO: Google 로그인 구현
             }
-            
+
             Spacer(modifier = Modifier.height(26.dp))
         }
     }

--- a/feature/login/src/main/java/com/multissue/wit/feature/login/LoginViewModel.kt
+++ b/feature/login/src/main/java/com/multissue/wit/feature/login/LoginViewModel.kt
@@ -19,7 +19,7 @@ class LoginViewModel @Inject constructor(
     override fun onIntent(intent: LoginUiIntent) {
         when (intent) {
             is LoginUiIntent.KakaoLoginClicked -> login(SocialType.KAKAO, intent.token)
-            // TODO: Google 로그인 처리
+            is LoginUiIntent.GoogleLoginClicked -> login(SocialType.GOOGLE, intent.token)
         }
     }
 

--- a/feature/login/src/main/java/com/multissue/wit/feature/login/LoginViewModel.kt
+++ b/feature/login/src/main/java/com/multissue/wit/feature/login/LoginViewModel.kt
@@ -1,12 +1,46 @@
 package com.multissue.wit.feature.login
 
-import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.multissue.wit.core.domain.model.auth.SocialType
+import com.multissue.wit.core.domain.usecase.auth.SocialLoginUseCase
+import com.multissue.wit.core.ui.base.BaseViewModel
+import com.multissue.wit.feature.login.state.LoginSideEffect
+import com.multissue.wit.feature.login.state.LoginUiIntent
+import com.multissue.wit.feature.login.state.LoginUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class LoginViewModel @Inject constructor(
+    private val socialLoginUseCase: SocialLoginUseCase,
+) : BaseViewModel<LoginUiState, LoginSideEffect, LoginUiIntent>(LoginUiState()) {
 
-) : ViewModel() {
+    override fun onIntent(intent: LoginUiIntent) {
+        when (intent) {
+            is LoginUiIntent.KakaoLoginClicked -> login(SocialType.KAKAO, intent.token)
+            // TODO: Google 로그인 처리
+        }
+    }
 
+    private fun login(socialType: SocialType, token: String) {
+        if (currentState.isLoading) return
+        setState { copy(isLoading = true) }
+
+        viewModelScope.launch {
+            socialLoginUseCase(socialType, token)
+                .onSuccess { result ->
+                    setState { copy(isLoading = false) }
+                    postSideEffect(LoginSideEffect.LoginSuccess(result.status))
+                }
+                .onFailure { throwable ->
+                    setState { copy(isLoading = false) }
+                    postSideEffect(
+                        LoginSideEffect.LoginError(
+                            throwable.message ?: "로그인에 실패했습니다."
+                        )
+                    )
+                }
+        }
+    }
 }

--- a/feature/login/src/main/java/com/multissue/wit/feature/login/navigation/LoginEntryProvider.kt
+++ b/feature/login/src/main/java/com/multissue/wit/feature/login/navigation/LoginEntryProvider.kt
@@ -5,11 +5,13 @@ import androidx.navigation3.runtime.NavKey
 import com.multissue.wit.feature.login.LoginScreen
 
 fun EntryProviderScope<NavKey>.loginEntry(
-    navigateToSignUp: () -> Unit
+    navigateToSignUp: () -> Unit,
+    navigateToMain: () -> Unit,
 ) {
     entry<LoginNavKey> {
         LoginScreen(
-            navigateToSignUp = navigateToSignUp
+            navigateToSignUp = navigateToSignUp,
+            navigateToMain = navigateToMain,
         )
     }
 }

--- a/feature/login/src/main/java/com/multissue/wit/feature/login/social/SocialLoginClient.kt
+++ b/feature/login/src/main/java/com/multissue/wit/feature/login/social/SocialLoginClient.kt
@@ -1,0 +1,46 @@
+package com.multissue.wit.feature.login.social
+
+import android.content.Context
+import com.kakao.sdk.common.model.ClientError
+import com.kakao.sdk.common.model.ClientErrorCause
+import com.kakao.sdk.user.UserApiClient
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+
+object SocialLoginClient {
+
+    suspend fun loginWithKakao(context: Context): String =
+        if (UserApiClient.instance.isKakaoTalkLoginAvailable(context)) {
+            try {
+                loginWithKakaoTalk(context)
+            } catch (e: Exception) {
+                if (e is ClientError && e.reason == ClientErrorCause.Cancelled) throw e
+                loginWithKakaoAccount(context)
+            }
+        } else {
+            loginWithKakaoAccount(context)
+        }
+
+    private suspend fun loginWithKakaoTalk(context: Context): String =
+        suspendCancellableCoroutine { cont ->
+            UserApiClient.instance.loginWithKakaoTalk(context) { token, error ->
+                when {
+                    error != null -> cont.resumeWithException(error)
+                    token != null -> cont.resume(token.accessToken)
+                    else -> cont.resumeWithException(IllegalStateException("카카오톡 로그인 실패"))
+                }
+            }
+        }
+
+    private suspend fun loginWithKakaoAccount(context: Context): String =
+        suspendCancellableCoroutine { cont ->
+            UserApiClient.instance.loginWithKakaoAccount(context) { token, error ->
+                when {
+                    error != null -> cont.resumeWithException(error)
+                    token != null -> cont.resume(token.accessToken)
+                    else -> cont.resumeWithException(IllegalStateException("카카오 계정 로그인 실패"))
+                }
+            }
+        }
+}

--- a/feature/login/src/main/java/com/multissue/wit/feature/login/social/SocialLoginClient.kt
+++ b/feature/login/src/main/java/com/multissue/wit/feature/login/social/SocialLoginClient.kt
@@ -1,10 +1,17 @@
 package com.multissue.wit.feature.login.social
 
 import android.content.Context
+import androidx.credentials.CredentialManager
+import androidx.credentials.GetCredentialRequest
+import com.google.android.libraries.identity.googleid.GetGoogleIdOption
+import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import com.kakao.sdk.common.model.ClientError
 import com.kakao.sdk.common.model.ClientErrorCause
 import com.kakao.sdk.user.UserApiClient
+import com.multissue.wit.feature.login.BuildConfig
 import kotlinx.coroutines.suspendCancellableCoroutine
+import java.security.SecureRandom
+import java.util.Base64
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
@@ -21,6 +28,24 @@ object SocialLoginClient {
         } else {
             loginWithKakaoAccount(context)
         }
+
+    suspend fun loginWithGoogle(context: Context): String {
+        val credentialManager = CredentialManager.create(context)
+
+        val googleIdOption = GetGoogleIdOption.Builder()
+            .setFilterByAuthorizedAccounts(false)
+            .setServerClientId(BuildConfig.GOOGLE_CLIENT_ID)
+            .setNonce(generateSecureRandomNonce())
+            .build()
+
+        val request = GetCredentialRequest.Builder()
+            .addCredentialOption(googleIdOption)
+            .build()
+
+        val result = credentialManager.getCredential(context, request)
+        val credential = GoogleIdTokenCredential.createFrom(result.credential.data)
+        return credential.idToken
+    }
 
     private suspend fun loginWithKakaoTalk(context: Context): String =
         suspendCancellableCoroutine { cont ->
@@ -43,4 +68,10 @@ object SocialLoginClient {
                 }
             }
         }
+
+    private fun generateSecureRandomNonce(byteLength: Int = 32): String {
+        val randomBytes = ByteArray(byteLength)
+        SecureRandom.getInstanceStrong().nextBytes(randomBytes)
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(randomBytes)
+    }
 }

--- a/feature/login/src/main/java/com/multissue/wit/feature/login/state/LoginState.kt
+++ b/feature/login/src/main/java/com/multissue/wit/feature/login/state/LoginState.kt
@@ -1,0 +1,20 @@
+package com.multissue.wit.feature.login.state
+
+import com.multissue.wit.core.domain.model.auth.AuthStatus
+import com.multissue.wit.core.ui.base.UiIntent
+import com.multissue.wit.core.ui.base.UiSideEffect
+import com.multissue.wit.core.ui.base.UiState
+
+data class LoginUiState(
+    val isLoading: Boolean = false,
+) : UiState
+
+sealed class LoginUiIntent : UiIntent {
+    data class KakaoLoginClicked(val token: String) : LoginUiIntent()
+    // TODO: Google 로그인 Intent 추가
+}
+
+sealed interface LoginSideEffect : UiSideEffect {
+    data class LoginSuccess(val status: AuthStatus) : LoginSideEffect
+    data class LoginError(val message: String) : LoginSideEffect
+}

--- a/feature/login/src/main/java/com/multissue/wit/feature/login/state/LoginState.kt
+++ b/feature/login/src/main/java/com/multissue/wit/feature/login/state/LoginState.kt
@@ -11,7 +11,7 @@ data class LoginUiState(
 
 sealed class LoginUiIntent : UiIntent {
     data class KakaoLoginClicked(val token: String) : LoginUiIntent()
-    // TODO: Google 로그인 Intent 추가
+    data class GoogleLoginClicked(val token: String) : LoginUiIntent()
 }
 
 sealed interface LoginSideEffect : UiSideEffect {

--- a/feature/login/src/main/res/values/strings.xml
+++ b/feature/login/src/main/res/values/strings.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="login_title_first">혼자일 때보다 안전하게</string>
+    <string name="login_title_second">함께라서 더 즐겁게!</string>
     <string name="kakao_login">카카오 로그인</string>
     <string name="google_login">구글 로그인</string>
 </resources>

--- a/feature/mypage/build.gradle.kts
+++ b/feature/mypage/build.gradle.kts
@@ -7,6 +7,8 @@ plugins {
 kotlin {
     sourceSets {
         dependencies {
+            implementation(projects.core.domain)
+
             implementation(libs.androidx.compose.material3)
             implementation(libs.coil.kt)
             implementation(libs.coil.kt.compose)

--- a/feature/mypage/src/main/java/com/multissue/wit/feature/mypage/MyPageScreen.kt
+++ b/feature/mypage/src/main/java/com/multissue/wit/feature/mypage/MyPageScreen.kt
@@ -60,6 +60,7 @@ fun MyPageScreen(
     modifier: Modifier = Modifier,
     viewModel: MyPageViewModel = hiltViewModel(),
     onBottomNavVisibilityChanged: (Boolean) -> Unit = {},
+    onNavigateToAuth: () -> Unit = {},
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -87,6 +88,7 @@ fun MyPageScreen(
         feedList = uiState.feedList,
         travelList = uiState.travelList,
         onBottomNavVisibilityChanged = onBottomNavVisibilityChanged,
+        onNavigateToAuth = onNavigateToAuth,
     )
 }
 
@@ -103,6 +105,7 @@ internal fun MyPageScreen(
     feedList: List<FeedItemState>,
     travelList: List<FeedItemState>,
     onBottomNavVisibilityChanged: (Boolean) -> Unit = {},
+    onNavigateToAuth: () -> Unit = {},
 ) {
     val focusManager = LocalFocusManager.current
 
@@ -205,6 +208,7 @@ internal fun MyPageScreen(
                         MyPageSettingsContent(
                             modifier = Modifier.padding(paddingValues),
                             onNavigateToProfileEdit = { onIntent(MyPageUiIntent.NavigateToProfileEdit) },
+                            onNavigateToAuth = onNavigateToAuth,
                         )
                     }
                     MyPageNav.PROFILE_EDIT -> {

--- a/feature/mypage/src/main/java/com/multissue/wit/feature/mypage/SettingsViewModel.kt
+++ b/feature/mypage/src/main/java/com/multissue/wit/feature/mypage/SettingsViewModel.kt
@@ -1,15 +1,21 @@
 package com.multissue.wit.feature.mypage
 
+import androidx.lifecycle.viewModelScope
+import com.multissue.wit.core.domain.exception.toUserMessage
+import com.multissue.wit.core.domain.usecase.auth.LogoutUseCase
 import com.multissue.wit.core.ui.base.BaseViewModel
+import com.multissue.wit.feature.mypage.state.UserInfoState
 import com.multissue.wit.feature.mypage.state.settings.SettingsUiIntent
 import com.multissue.wit.feature.mypage.state.settings.SettingsUiSideEffect
 import com.multissue.wit.feature.mypage.state.settings.SettingsUiState
-import com.multissue.wit.feature.mypage.state.UserInfoState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class SettingsViewModel @Inject constructor() :
+class SettingsViewModel @Inject constructor(
+    private val logoutUseCase: LogoutUseCase,
+) :
     BaseViewModel<SettingsUiState, SettingsUiSideEffect, SettingsUiIntent>(SettingsUiState()) {
 
     override fun onIntent(intent: SettingsUiIntent) {
@@ -28,7 +34,11 @@ class SettingsViewModel @Inject constructor() :
             }
             SettingsUiIntent.ConfirmLogout -> {
                 setState { copy(showLogoutDialog = false) }
-                // TODO 로그아웃 처리
+                viewModelScope.launch {
+                    logoutUseCase()
+                        .onSuccess { postSideEffect(SettingsUiSideEffect.NavigateToAuth) }
+                        .onFailure { setState { copy(errorMessage = it.toUserMessage()) } }
+                }
             }
             SettingsUiIntent.ClickWithdraw -> {
                 setState { copy(showWithdrawDialog = true) }
@@ -43,6 +53,9 @@ class SettingsViewModel @Inject constructor() :
             SettingsUiIntent.DismissWithdrawCompleteDialog -> {
                 setState { copy(showWithdrawCompleteDialog = false) }
                 // TODO 탈퇴 완료 후 로그인 화면 이동
+            }
+            SettingsUiIntent.DismissErrorDialog -> {
+                setState { copy(errorMessage = null) }
             }
         }
     }

--- a/feature/mypage/src/main/java/com/multissue/wit/feature/mypage/component/settings/MyPageSettingsContent.kt
+++ b/feature/mypage/src/main/java/com/multissue/wit/feature/mypage/component/settings/MyPageSettingsContent.kt
@@ -23,6 +23,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.multissue.wit.designsystem.component.dialog.WitDialog
 import com.multissue.wit.designsystem.component.dialog.WitDialogDefaultLayout
+import com.multissue.wit.designsystem.component.dialog.WitErrorDialog
 import com.multissue.wit.designsystem.component.dialog.WitDialogMessage
 import com.multissue.wit.designsystem.component.dialog.WitDialogOnlyTitle
 import com.multissue.wit.designsystem.component.dialog.WitDialogRightButton
@@ -39,6 +40,7 @@ import com.multissue.wit.feature.mypage.state.settings.SettingsUiSideEffect
 fun MyPageSettingsContent(
     modifier: Modifier = Modifier,
     onNavigateToProfileEdit: () -> Unit = {},
+    onNavigateToAuth: () -> Unit = {},
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -47,6 +49,7 @@ fun MyPageSettingsContent(
         viewModel.sideEffect.collect { effect ->
             when (effect) {
                 SettingsUiSideEffect.NavigateToProfileEdit -> onNavigateToProfileEdit()
+                SettingsUiSideEffect.NavigateToAuth -> onNavigateToAuth()
             }
         }
     }
@@ -58,6 +61,7 @@ fun MyPageSettingsContent(
         showLogoutDialog = uiState.showLogoutDialog,
         showWithdrawDialog = uiState.showWithdrawDialog,
         showWithdrawCompleteDialog = uiState.showWithdrawCompleteDialog,
+        errorMessage = uiState.errorMessage,
         onIntent = viewModel::onIntent,
     )
 }
@@ -70,6 +74,7 @@ internal fun MyPageSettingsContent(
     showLogoutDialog: Boolean,
     showWithdrawDialog: Boolean,
     showWithdrawCompleteDialog: Boolean,
+    errorMessage: String? = null,
     onIntent: (SettingsUiIntent) -> Unit,
 ) {
     Column(
@@ -189,4 +194,9 @@ internal fun MyPageSettingsContent(
             )
         }
     }
+
+    WitErrorDialog(
+        errorMessage = errorMessage,
+        onDismiss = { onIntent(SettingsUiIntent.DismissErrorDialog) }
+    )
 }

--- a/feature/mypage/src/main/java/com/multissue/wit/feature/mypage/navigation/MyPageEntryProvider.kt
+++ b/feature/mypage/src/main/java/com/multissue/wit/feature/mypage/navigation/MyPageEntryProvider.kt
@@ -2,17 +2,17 @@ package com.multissue.wit.feature.mypage.navigation
 
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
-import com.multissue.wit.core.navigation.Navigator
 import com.multissue.wit.feature.mypage.MyPageScreen
 
 fun EntryProviderScope<NavKey>.myPageEntry(
-    navigator: Navigator,
     onBottomNavVisibilityChanged: (Boolean) -> Unit = {},
+    onNavigateToAuth: () -> Unit = {},
 ) {
     // TODO SnackBar
     entry<MyPageNavKey> {
         MyPageScreen(
             onBottomNavVisibilityChanged = onBottomNavVisibilityChanged,
+            onNavigateToAuth = onNavigateToAuth,
         )
     }
 }

--- a/feature/mypage/src/main/java/com/multissue/wit/feature/mypage/state/settings/SettingsUiState.kt
+++ b/feature/mypage/src/main/java/com/multissue/wit/feature/mypage/state/settings/SettingsUiState.kt
@@ -11,10 +11,12 @@ data class SettingsUiState(
     val showLogoutDialog: Boolean = false,
     val showWithdrawDialog: Boolean = false,
     val showWithdrawCompleteDialog: Boolean = false,
+    val errorMessage: String? = null,
 ) : UiState
 
 sealed interface SettingsUiSideEffect : UiSideEffect {
     data object NavigateToProfileEdit : SettingsUiSideEffect
+    data object NavigateToAuth : SettingsUiSideEffect
 }
 
 sealed interface SettingsUiIntent : UiIntent {
@@ -27,4 +29,5 @@ sealed interface SettingsUiIntent : UiIntent {
     data object DismissWithdrawDialog : SettingsUiIntent
     data object ConfirmWithdraw : SettingsUiIntent
     data object DismissWithdrawCompleteDialog : SettingsUiIntent
+    data object DismissErrorDialog : SettingsUiIntent
 }

--- a/feature/signup/build.gradle.kts
+++ b/feature/signup/build.gradle.kts
@@ -9,6 +9,7 @@ kotlin {
         dependencies {
             implementation(libs.androidx.compose.material3)
             implementation(libs.kotlinx.datetime)
+            implementation(projects.core.domain)
         }
     }
 }

--- a/feature/signup/src/main/java/com/multissue/wit/feature/signup/SignupScreen.kt
+++ b/feature/signup/src/main/java/com/multissue/wit/feature/signup/SignupScreen.kt
@@ -40,6 +40,7 @@ import com.multissue.wit.feature.signup.component.NicknamePage
 import com.multissue.wit.feature.signup.component.SelectDateDialog
 import com.multissue.wit.feature.signup.component.SignupAgreementBottomSheet
 import com.multissue.wit.feature.signup.component.TermsDialog
+import com.multissue.wit.designsystem.component.dialog.WitErrorDialog
 import com.multissue.wit.feature.signup.state.SignUpStep
 import com.multissue.wit.feature.signup.state.SignupUiIntent
 import com.multissue.wit.feature.signup.state.SignupUiState
@@ -61,6 +62,11 @@ fun SignupRoute(
         onIntent = signupViewModel::onIntent,
         navigateToMain = navigateToHome,
         navigateToLogin = navigateToLogin,
+    )
+
+    WitErrorDialog(
+        errorMessage = uiState.errorMessage,
+        onDismiss = { signupViewModel.onIntent(SignupUiIntent.DismissError) },
     )
 }
 

--- a/feature/signup/src/main/java/com/multissue/wit/feature/signup/SignupScreen.kt
+++ b/feature/signup/src/main/java/com/multissue/wit/feature/signup/SignupScreen.kt
@@ -51,7 +51,7 @@ fun SignupRoute(
     modifier: Modifier = Modifier,
     signupViewModel: SignupViewModel = hiltViewModel(),
     navigateToLogin: () -> Unit,
-    navigateToHome: () -> Unit
+    navigateToHome: () -> Unit,
 ) {
     val uiState by signupViewModel.uiState.collectAsStateWithLifecycle()
 
@@ -60,7 +60,7 @@ fun SignupRoute(
         signupUiState = uiState,
         onIntent = signupViewModel::onIntent,
         navigateToMain = navigateToHome,
-        navigateToLogin = navigateToLogin
+        navigateToLogin = navigateToLogin,
     )
 }
 

--- a/feature/signup/src/main/java/com/multissue/wit/feature/signup/SignupScreen.kt
+++ b/feature/signup/src/main/java/com/multissue/wit/feature/signup/SignupScreen.kt
@@ -190,18 +190,16 @@ fun SignupScreen(
                     }
                 }
                 SignupAgreementBottomSheet(
-                    state = signupUiState.agreementState,
-                    onStateChange = { type, checked ->
-                        onIntent(SignupUiIntent.CheckAgreement(type, checked))
-                    },
-                    onShowTermsDialog = {
-                        onIntent(SignupUiIntent.ShowTermsDialog)
-                    },
-                    onConfirm = {
-                        onIntent(SignupUiIntent.SignupComplete)
-                    },
+                    visible = signupUiState.showAgreementBottomSheet,
+                    termItems = signupUiState.termItems,
+                    agreedTermIds = signupUiState.agreedTermIds,
+                    isAllAgreed = signupUiState.isAllTermsAgreed,
+                    isRequiredAgreed = signupUiState.isRequiredTermsAgreed,
+                    onToggleTerm = { onIntent(SignupUiIntent.ToggleTermAgreement(it)) },
+                    onToggleAll = { onIntent(SignupUiIntent.ToggleAllTerms) },
+                    onShowTermsContent = { onIntent(SignupUiIntent.ShowTermsContent(it)) },
+                    onConfirm = { onIntent(SignupUiIntent.SubmitAgreement) },
                     onDismiss = { onIntent(SignupUiIntent.HideAgreementBottomSheet) },
-                    visible = signupUiState.showAgreementBottomSheet
                 )
             }
 
@@ -219,9 +217,9 @@ fun SignupScreen(
             )
 
             TermsDialog(
-                showDialog = signupUiState.showTermsDialog,
+                contentUrl = signupUiState.termsContentUrl,
                 onDismiss = {
-                    onIntent(SignupUiIntent.HideTermsDialog)
+                    onIntent(SignupUiIntent.HideTermsContent)
                 }
             )
         }

--- a/feature/signup/src/main/java/com/multissue/wit/feature/signup/SignupViewModel.kt
+++ b/feature/signup/src/main/java/com/multissue/wit/feature/signup/SignupViewModel.kt
@@ -1,6 +1,7 @@
 package com.multissue.wit.feature.signup
 
 import androidx.lifecycle.viewModelScope
+import com.multissue.wit.core.domain.exception.WitException
 import com.multissue.wit.core.domain.exception.toUserMessage
 import com.multissue.wit.core.domain.usecase.terms.AgreeTermsUseCase
 import com.multissue.wit.core.domain.usecase.terms.GetActiveTermsUseCase
@@ -64,8 +65,12 @@ class SignupViewModel @Inject constructor(
                         )
                     }
                 }
-                .onFailure {
-                    setState { copy(errorMessage = it.toUserMessage()) }
+                .onFailure { error ->
+                    if (error is WitException.HttpException && error.code == 409) {
+                        setState { copy(isNickNameDuplicated = true, isCheckedNickname = true) }
+                    } else {
+                        setState { copy(errorMessage = error.toUserMessage()) }
+                    }
                 }
         }
     }

--- a/feature/signup/src/main/java/com/multissue/wit/feature/signup/SignupViewModel.kt
+++ b/feature/signup/src/main/java/com/multissue/wit/feature/signup/SignupViewModel.kt
@@ -2,9 +2,10 @@ package com.multissue.wit.feature.signup
 
 import androidx.lifecycle.viewModelScope
 import com.multissue.wit.core.domain.exception.toUserMessage
+import com.multissue.wit.core.domain.usecase.terms.AgreeTermsUseCase
+import com.multissue.wit.core.domain.usecase.terms.GetActiveTermsUseCase
 import com.multissue.wit.core.domain.usecase.user.CheckNicknameDuplicateUseCase
 import com.multissue.wit.core.ui.base.BaseViewModel
-import com.multissue.wit.feature.signup.state.agreement.AgreementType
 import com.multissue.wit.feature.signup.state.GenderType
 import com.multissue.wit.feature.signup.state.SignupSideEffect
 import com.multissue.wit.feature.signup.state.SignupUiIntent
@@ -16,6 +17,8 @@ import javax.inject.Inject
 @HiltViewModel
 class SignupViewModel @Inject constructor(
     private val checkNicknameDuplicateUseCase: CheckNicknameDuplicateUseCase,
+    private val getActiveTermsUseCase: GetActiveTermsUseCase,
+    private val agreeTermsUseCase: AgreeTermsUseCase,
 ) : BaseViewModel<SignupUiState, SignupSideEffect, SignupUiIntent>(
     initialState = SignupUiState()
 ) {
@@ -23,16 +26,17 @@ class SignupViewModel @Inject constructor(
         when (intent) {
             is SignupUiIntent.SetNickname -> onNicknameChange(intent.nickname)
             is SignupUiIntent.CheckNickNameDuplicate -> onCheckNickNameDuplicate()
-            is SignupUiIntent.ShowBirthSelectDialog -> onShowBirthSettingDialog()
-            is SignupUiIntent.HideBirthSelectDialog -> onHideBirthSettingDialog()
+            is SignupUiIntent.ShowBirthSelectDialog -> onShowBirthSelectDialog()
+            is SignupUiIntent.HideBirthSelectDialog -> onHideBirthSelectDialog()
             is SignupUiIntent.SelectBirthDate -> onSelectBirthDate(intent.year, intent.month, intent.day)
             is SignupUiIntent.SetGender -> onGenderChange(intent.gender)
             is SignupUiIntent.ShowAgreementBottomSheet -> onShowAgreementBottomSheet()
             is SignupUiIntent.HideAgreementBottomSheet -> onHideAgreementBottomSheet()
-            is SignupUiIntent.CheckAgreement -> onCheckAgreement(intent.type, intent.checked)
-            is SignupUiIntent.ShowTermsDialog -> onShowTermsDialog()
-            is SignupUiIntent.HideTermsDialog -> onHideTermsDialog()
-            is SignupUiIntent.SignupComplete -> onSignupComplete()
+            is SignupUiIntent.ToggleTermAgreement -> onToggleTermAgreement(intent.termId)
+            is SignupUiIntent.ToggleAllTerms -> onToggleAllTerms()
+            is SignupUiIntent.ShowTermsContent -> onShowTermsContent(intent.contentUrl)
+            is SignupUiIntent.HideTermsContent -> onHideTermsContent()
+            is SignupUiIntent.SubmitAgreement -> onSubmitAgreement()
             is SignupUiIntent.DismissError -> onDismissError()
         }
     }
@@ -64,26 +68,16 @@ class SignupViewModel @Inject constructor(
         }
     }
 
-    private fun onSelectBirthDate(
-        year: Int,
-        month: Int,
-        day: Int
-    ) {
-        setState {
-            copy(
-                birthYear = year,
-                birthMonth = month,
-                birthDay = day
-            )
-        }
-    }
-
-    private fun onShowBirthSettingDialog() {
+    private fun onShowBirthSelectDialog() {
         setState { copy(showBirthSelectDialog = true) }
     }
 
-    private fun onHideBirthSettingDialog() {
+    private fun onHideBirthSelectDialog() {
         setState { copy(showBirthSelectDialog = false) }
+    }
+
+    private fun onSelectBirthDate(year: Int, month: Int, day: Int) {
+        setState { copy(birthYear = year, birthMonth = month, birthDay = day) }
     }
 
     private fun onGenderChange(gender: GenderType) {
@@ -91,87 +85,68 @@ class SignupViewModel @Inject constructor(
     }
 
     private fun onShowAgreementBottomSheet() {
-        setState { copy(showAgreementBottomSheet = true) }
+        if (currentState.termItems.isEmpty()) {
+            loadTerms()
+        }
+    }
+
+    private fun loadTerms() {
+        viewModelScope.launch {
+            getActiveTermsUseCase()
+                .onSuccess { terms ->
+                    setState { copy(termItems = terms, showAgreementBottomSheet = true) }
+                }
+                .onFailure {
+                    setState { copy(errorMessage = it.toUserMessage()) }
+                }
+        }
     }
 
     private fun onHideAgreementBottomSheet() {
         setState { copy(showAgreementBottomSheet = false) }
     }
 
-    private fun onCheckAgreement(
-        type: AgreementType,
-        checked: Boolean
-    ) {
-        when (type) {
-            AgreementType.ALL -> setState {
-                copy(
-                    agreementState = agreementState.copy(
-                        terms = checked,
-                        location = checked,
-                        marketing = checked,
-                    )
-                )
-            }
-            AgreementType.TERMS -> {
-                setState {
-                    copy(
-                        agreementState = agreementState.copy(
-                            terms = checked,
-                        )
-                    )
-                }
-            }
-            AgreementType.LOCATION -> {
-                setState {
-                    copy(
-                        agreementState = agreementState.copy(
-                            location = checked,
-                        )
-                    )
-                }
-            }
-            AgreementType.MARKETING -> {
-                setState {
-                    copy(
-                        agreementState = agreementState.copy(
-                            marketing = checked,
-                        )
-                    )
-                }
-            }
-        }
+    private fun onShowTermsContent(contentUrl: String) {
+        setState { copy(termsContentUrl = contentUrl) }
     }
 
-    private fun onShowTermsDialog() {
-        setState {
-            copy(
-                showTermsDialog = true
-            )
-        }
+    private fun onHideTermsContent() {
+        setState { copy(termsContentUrl = "") }
     }
 
-    private fun onHideTermsDialog() {
-        setState {
-            copy(
-                showTermsDialog = false
-            )
-        }
+    private fun onToggleTermAgreement(termId: String) {
+        val current = currentState.agreedTermIds
+        val updated = if (termId in current) current - termId else current + termId
+        setState { copy(agreedTermIds = updated) }
     }
 
-    private fun onSignupComplete() {
-        setState {
-            copy(
-                showAgreementBottomSheet = false,
-                signupComplete = true
-            )
-        }
+    private fun onToggleAllTerms() {
+        val allIds = currentState.termItems.map { it.id }.toSet()
+        val updated = if (currentState.isAllTermsAgreed) emptySet<String>() else allIds
+        setState { copy(agreedTermIds = updated) }
     }
 
     private fun onDismissError() {
-        setState {
-            copy(
-                errorMessage = null
-            )
+        setState { copy(errorMessage = null) }
+    }
+
+    private fun onSubmitAgreement() {
+        viewModelScope.launch {
+            val agreements = currentState.termItems.map { term ->
+                term.id to (term.id in currentState.agreedTermIds)
+            }
+            agreeTermsUseCase(agreements)
+                .onSuccess {
+                    setState {
+                        copy(
+                            showAgreementBottomSheet = false,
+                            signupComplete = true
+                        )
+                    }
+                }
+                .onFailure {
+                    setState { copy(errorMessage = it.toUserMessage()) }
+                }
         }
     }
 }

--- a/feature/signup/src/main/java/com/multissue/wit/feature/signup/SignupViewModel.kt
+++ b/feature/signup/src/main/java/com/multissue/wit/feature/signup/SignupViewModel.kt
@@ -1,5 +1,8 @@
 package com.multissue.wit.feature.signup
 
+import androidx.lifecycle.viewModelScope
+import com.multissue.wit.core.domain.exception.toUserMessage
+import com.multissue.wit.core.domain.usecase.user.CheckNicknameDuplicateUseCase
 import com.multissue.wit.core.ui.base.BaseViewModel
 import com.multissue.wit.feature.signup.state.agreement.AgreementType
 import com.multissue.wit.feature.signup.state.GenderType
@@ -7,11 +10,12 @@ import com.multissue.wit.feature.signup.state.SignupSideEffect
 import com.multissue.wit.feature.signup.state.SignupUiIntent
 import com.multissue.wit.feature.signup.state.SignupUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class SignupViewModel @Inject constructor(
-
+    private val checkNicknameDuplicateUseCase: CheckNicknameDuplicateUseCase,
 ) : BaseViewModel<SignupUiState, SignupSideEffect, SignupUiIntent>(
     initialState = SignupUiState()
 ) {
@@ -29,6 +33,7 @@ class SignupViewModel @Inject constructor(
             is SignupUiIntent.ShowTermsDialog -> onShowTermsDialog()
             is SignupUiIntent.HideTermsDialog -> onHideTermsDialog()
             is SignupUiIntent.SignupComplete -> onSignupComplete()
+            is SignupUiIntent.DismissError -> onDismissError()
         }
     }
 
@@ -43,12 +48,19 @@ class SignupViewModel @Inject constructor(
     }
 
     private fun onCheckNickNameDuplicate() {
-        // TODO("서버에서 NickName check")
-        setState {
-            copy(
-                isNickNameDuplicated = false,
-                isCheckedNickname = true
-            )
+        viewModelScope.launch {
+            checkNicknameDuplicateUseCase(currentState.nickname)
+                .onSuccess { isAvailable ->
+                    setState {
+                        copy(
+                            isNickNameDuplicated = !isAvailable,
+                            isCheckedNickname = true
+                        )
+                    }
+                }
+                .onFailure {
+                    setState { copy(errorMessage = it.toUserMessage()) }
+                }
         }
     }
 
@@ -151,6 +163,14 @@ class SignupViewModel @Inject constructor(
             copy(
                 showAgreementBottomSheet = false,
                 signupComplete = true
+            )
+        }
+    }
+
+    private fun onDismissError() {
+        setState {
+            copy(
+                errorMessage = null
             )
         }
     }

--- a/feature/signup/src/main/java/com/multissue/wit/feature/signup/SignupViewModel.kt
+++ b/feature/signup/src/main/java/com/multissue/wit/feature/signup/SignupViewModel.kt
@@ -5,6 +5,7 @@ import com.multissue.wit.core.domain.exception.toUserMessage
 import com.multissue.wit.core.domain.usecase.terms.AgreeTermsUseCase
 import com.multissue.wit.core.domain.usecase.terms.GetActiveTermsUseCase
 import com.multissue.wit.core.domain.usecase.user.CheckNicknameDuplicateUseCase
+import com.multissue.wit.core.domain.usecase.user.CompleteOnboardingUseCase
 import com.multissue.wit.core.ui.base.BaseViewModel
 import com.multissue.wit.feature.signup.state.GenderType
 import com.multissue.wit.feature.signup.state.SignupSideEffect
@@ -19,6 +20,7 @@ class SignupViewModel @Inject constructor(
     private val checkNicknameDuplicateUseCase: CheckNicknameDuplicateUseCase,
     private val getActiveTermsUseCase: GetActiveTermsUseCase,
     private val agreeTermsUseCase: AgreeTermsUseCase,
+    private val completeOnboardingUseCase: CompleteOnboardingUseCase,
 ) : BaseViewModel<SignupUiState, SignupSideEffect, SignupUiIntent>(
     initialState = SignupUiState()
 ) {
@@ -137,16 +139,30 @@ class SignupViewModel @Inject constructor(
             }
             agreeTermsUseCase(agreements)
                 .onSuccess {
-                    setState {
-                        copy(
-                            showAgreementBottomSheet = false,
-                            signupComplete = true
-                        )
-                    }
+                    setState { copy(showAgreementBottomSheet = false) }
+                    completeOnboarding()
                 }
                 .onFailure {
                     setState { copy(errorMessage = it.toUserMessage()) }
                 }
         }
+    }
+
+    private suspend fun completeOnboarding() {
+        val state = currentState
+        val birthDate = "%04d-%02d-%02d".format(state.birthYear, state.birthMonth, state.birthDay)
+        val gender = state.gender.name
+        completeOnboardingUseCase(
+            nickname = state.nickname,
+            gender = gender,
+            birthDate = birthDate,
+            profileImagePath = null,
+        )
+            .onSuccess {
+                setState { copy(signupComplete = true) }
+            }
+            .onFailure {
+                setState { copy(errorMessage = it.toUserMessage()) }
+            }
     }
 }

--- a/feature/signup/src/main/java/com/multissue/wit/feature/signup/component/AgreementAllItem.kt
+++ b/feature/signup/src/main/java/com/multissue/wit/feature/signup/component/AgreementAllItem.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.unit.dp
 import com.multissue.wit.designsystem.theme.WitTheme
 import com.multissue.wit.designsystem.util.noRippleClickable
 import com.multissue.wit.feature.signup.R
-import com.multissue.wit.feature.signup.state.agreement.AgreementType
 
 @Composable
 fun AgreementAllItem(

--- a/feature/signup/src/main/java/com/multissue/wit/feature/signup/component/AgreementBottomSheet.kt
+++ b/feature/signup/src/main/java/com/multissue/wit/feature/signup/component/AgreementBottomSheet.kt
@@ -15,17 +15,20 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.multissue.wit.core.domain.model.terms.TermItem
 import com.multissue.wit.designsystem.theme.WitTheme
-import com.multissue.wit.feature.signup.state.SignupUiState
-import com.multissue.wit.feature.signup.state.agreement.AgreementType
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SignupAgreementBottomSheet(
-    state: SignupUiState.AgreementState,
     visible: Boolean,
-    onStateChange: (AgreementType, Boolean) -> Unit,
-    onShowTermsDialog: () -> Unit,
+    termItems: List<TermItem>,
+    agreedTermIds: Set<String>,
+    isAllAgreed: Boolean,
+    isRequiredAgreed: Boolean,
+    onToggleTerm: (String) -> Unit,
+    onToggleAll: () -> Unit,
+    onShowTermsContent: (String) -> Unit,
     onConfirm: () -> Unit,
     onDismiss: () -> Unit,
 ) {
@@ -54,10 +57,14 @@ fun SignupAgreementBottomSheet(
         }
     ) {
         AgreementContent(
-            state = state,
-            onStateChange = onStateChange,
-            onShowTermsDialog = onShowTermsDialog,
-            onConfirm = onConfirm
+            termItems = termItems,
+            agreedTermIds = agreedTermIds,
+            isAllAgreed = isAllAgreed,
+            isRequiredAgreed = isRequiredAgreed,
+            onToggleTerm = onToggleTerm,
+            onToggleAll = onToggleAll,
+            onShowTermsContent = onShowTermsContent,
+            onConfirm = onConfirm,
         )
     }
 }

--- a/feature/signup/src/main/java/com/multissue/wit/feature/signup/component/AgreementContent.kt
+++ b/feature/signup/src/main/java/com/multissue/wit/feature/signup/component/AgreementContent.kt
@@ -8,35 +8,24 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.multissue.wit.core.domain.model.terms.TermItem
 import com.multissue.wit.designsystem.theme.WitTheme
 import com.multissue.wit.feature.signup.R
-import com.multissue.wit.feature.signup.state.SignupUiState
-import com.multissue.wit.feature.signup.state.agreement.AgreementType
 
 @Composable
 fun AgreementContent(
-    state: SignupUiState.AgreementState,
-    onStateChange: (AgreementType, Boolean) -> Unit,
-    onShowTermsDialog: () -> Unit,
-    onConfirm: () -> Unit
+    termItems: List<TermItem>,
+    agreedTermIds: Set<String>,
+    isAllAgreed: Boolean,
+    isRequiredAgreed: Boolean,
+    onToggleTerm: (String) -> Unit,
+    onToggleAll: () -> Unit,
+    onShowTermsContent: (String) -> Unit,
+    onConfirm: () -> Unit,
 ) {
-    val terms by rememberUpdatedState(state.terms)
-    val location by rememberUpdatedState(state.location)
-    val marketing by rememberUpdatedState(state.marketing)
-
-    val isAllChecked by remember {
-        derivedStateOf {
-            terms && location && marketing
-        }
-    }
-
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -52,8 +41,8 @@ fun AgreementContent(
         AgreementAllItem(
             modifier = Modifier.padding(vertical = 12.dp),
             title = stringResource(R.string.agreement_all_title),
-            checked = isAllChecked,
-            onCheckedChange = { onStateChange(AgreementType.ALL, it) }
+            checked = isAllAgreed,
+            onCheckedChange = { onToggleAll() }
         )
 
         HorizontalDivider(
@@ -63,43 +52,26 @@ fun AgreementContent(
 
         Spacer(Modifier.height(20.dp))
 
-        AgreementItem(
-            modifier = Modifier.padding(vertical = 8.dp),
-            title = stringResource(R.string.agreement_terms_title),
-            checked = state.terms,
-            onShowAgreementDescription = {
-                // TODO("API 연결 시 약관 Type에 따라 분기")
-                onShowTermsDialog()
-            },
-            onCheckedChange = { onStateChange(AgreementType.TERMS, it) }
-        )
+        termItems.forEach { term ->
+            val label = if (term.required) {
+                "${term.title} (${stringResource(R.string.agreement_required)})"
+            } else {
+                "${term.title} (${stringResource(R.string.agreement_optional)})"
+            }
 
-        AgreementItem(
-            modifier = Modifier.padding(vertical = 8.dp),
-            title = stringResource(R.string.agreement_location_title),
-            checked = state.location,
-            onShowAgreementDescription = {
-                // TODO("API 연결 시 약관 Type에 따라 분기")
-                onShowTermsDialog()
-            },
-            onCheckedChange = { onStateChange(AgreementType.LOCATION, it) }
-        )
-
-        AgreementItem(
-            modifier = Modifier.padding(vertical = 8.dp),
-            title = stringResource(R.string.agreement_marketing_title),
-            checked = state.marketing,
-            onShowAgreementDescription = {
-                // TODO("API 연결 시 약관 Type에 따라 분기")
-                onShowTermsDialog()
-            },
-            onCheckedChange = { onStateChange(AgreementType.MARKETING, it) }
-        )
+            AgreementItem(
+                modifier = Modifier.padding(vertical = 8.dp),
+                title = label,
+                checked = term.id in agreedTermIds,
+                onShowAgreementDescription = { term.contentUrl?.let(onShowTermsContent) },
+                onCheckedChange = { onToggleTerm(term.id) }
+            )
+        }
 
         Spacer(Modifier.height(36.dp))
 
         SignupBottomButton(
-            enabled = state.isRequiredAccepted,
+            enabled = isRequiredAgreed,
             onClick = onConfirm
         )
 

--- a/feature/signup/src/main/java/com/multissue/wit/feature/signup/component/NicknamePage.kt
+++ b/feature/signup/src/main/java/com/multissue/wit/feature/signup/component/NicknamePage.kt
@@ -82,7 +82,7 @@ fun NicknamePage(
 
             SignupBottomButton(
                 modifier = Modifier.padding(bottom = 22.dp),
-                enabled = isCheckedNickname && nickName.isNotBlank(),
+                enabled = isCheckedNickname && isNickNameDuplicated == false && nickName.isNotBlank(),
                 onClick = {
                     scope.launch {
                         pagerState.animateScrollToPage(

--- a/feature/signup/src/main/java/com/multissue/wit/feature/signup/component/TermsDialog.kt
+++ b/feature/signup/src/main/java/com/multissue/wit/feature/signup/component/TermsDialog.kt
@@ -1,36 +1,46 @@
 package com.multissue.wit.feature.signup.component
 
+import android.webkit.WebView
+import android.webkit.WebViewClient
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.multissue.wit.designsystem.component.background.WitBackground
 
 @Composable
 fun TermsDialog(
-    showDialog: Boolean,
-    onDismiss: () -> Unit
+    contentUrl: String,
+    onDismiss: () -> Unit,
 ) {
-    if (showDialog) {
-        Dialog(
-            onDismissRequest = onDismiss,
-            properties = DialogProperties(
-                usePlatformDefaultWidth = false,
-                decorFitsSystemWindows = false
-            )
-        ) {
-            WitBackground(
-                modifier = Modifier
-                    .fillMaxSize()
-            ) {
-                TermsDialogContent(
-                    onDismiss = onDismiss,
-                    content = {
+    if (contentUrl.isEmpty()) return
 
-                    }
-                )
-            }
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+            decorFitsSystemWindows = false
+        )
+    ) {
+        WitBackground(
+            modifier = Modifier.fillMaxSize()
+        ) {
+            TermsDialogContent(
+                onDismiss = onDismiss,
+                content = {
+                    AndroidView(
+                        modifier = Modifier.fillMaxSize(),
+                        factory = { context ->
+                            WebView(context).apply {
+                                webViewClient = WebViewClient()
+                                loadUrl(contentUrl)
+                            }
+                        }
+                    )
+                }
+            )
         }
     }
 }

--- a/feature/signup/src/main/java/com/multissue/wit/feature/signup/component/TermsDialogContent.kt
+++ b/feature/signup/src/main/java/com/multissue/wit/feature/signup/component/TermsDialogContent.kt
@@ -5,13 +5,9 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
@@ -24,10 +20,10 @@ import com.multissue.wit.designsystem.component.topbar.WitCenterAlignedTopAppBar
 @Composable
 fun TermsDialogContent(
     onDismiss: () -> Unit,
-    content: @Composable ColumnScope.() -> Unit
+    content: @Composable () -> Unit
 ) {
     AnimatedVisibility(
-        visible = true, // TODO("API 연결 시 하드 코딩 변경")
+        visible = true,
         enter = slideInVertically(
             initialOffsetY = { it },
             animationSpec = tween(800)
@@ -51,18 +47,12 @@ fun TermsDialogContent(
                     }
                 }
             )
-            Column(
-                modifier = Modifier
-                    .weight(1f)
-                    .verticalScroll(rememberScrollState())
-                    .padding(horizontal = 26.dp)
-            ) {
-                Spacer(modifier = Modifier.height(24.dp))
+            Spacer(modifier = Modifier.height(24.dp))
 
-                content()
+            content()
 
-                Spacer(modifier = Modifier.height(24.dp))
-            }
+            Spacer(modifier = Modifier.height(24.dp))
+
         }
     }
 }

--- a/feature/signup/src/main/java/com/multissue/wit/feature/signup/component/TermsDialogContent.kt
+++ b/feature/signup/src/main/java/com/multissue/wit/feature/signup/component/TermsDialogContent.kt
@@ -47,12 +47,7 @@ fun TermsDialogContent(
                     }
                 }
             )
-            Spacer(modifier = Modifier.height(24.dp))
-
             content()
-
-            Spacer(modifier = Modifier.height(24.dp))
-
         }
     }
 }

--- a/feature/signup/src/main/java/com/multissue/wit/feature/signup/navigation/SignupEntryProvider.kt
+++ b/feature/signup/src/main/java/com/multissue/wit/feature/signup/navigation/SignupEntryProvider.kt
@@ -11,7 +11,7 @@ fun EntryProviderScope<NavKey>.signupEntry(
     entry<SignupNavKey> {
         SignupRoute(
             navigateToLogin = navigateToLogin,
-            navigateToHome = navigateToMain
+            navigateToHome = navigateToMain,
         )
     }
 }

--- a/feature/signup/src/main/java/com/multissue/wit/feature/signup/state/SignupUiState.kt
+++ b/feature/signup/src/main/java/com/multissue/wit/feature/signup/state/SignupUiState.kt
@@ -1,9 +1,9 @@
 package com.multissue.wit.feature.signup.state
 
+import com.multissue.wit.core.domain.model.terms.TermItem
 import com.multissue.wit.core.ui.base.UiIntent
 import com.multissue.wit.core.ui.base.UiSideEffect
 import com.multissue.wit.core.ui.base.UiState
-import com.multissue.wit.feature.signup.state.agreement.AgreementType
 
 data class SignupUiState(
     val nickname: String = "",
@@ -17,22 +17,20 @@ data class SignupUiState(
 
     val gender: GenderType = GenderType.NONE,
     val showAgreementBottomSheet: Boolean = false,
-    val agreementState: AgreementState = AgreementState(),
-    val showTermsDialog: Boolean = false,
+    val termItems: List<TermItem> = emptyList(),
+    val agreedTermIds: Set<String> = emptySet(),
+    val termsContentUrl: String = "",
     val signupComplete: Boolean = false,
     val errorMessage: String? = null
 ) : UiState {
     val hasBirthDate: Boolean
         get() = birthYear != 0 && birthMonth != 0 && birthDay != 0
 
-    data class AgreementState(
-        val terms: Boolean = false,       // 필수
-        val location: Boolean = false,    // 필수
-        val marketing: Boolean = false    // 선택
-    ) {
-        val isRequiredAccepted: Boolean
-            get() = terms && location
-    }
+    val isAllTermsAgreed: Boolean
+        get() = termItems.isNotEmpty() && termItems.all { it.id in agreedTermIds }
+
+    val isRequiredTermsAgreed: Boolean
+        get() = termItems.filter { it.required }.all { it.id in agreedTermIds }
 }
 
 sealed class SignupUiIntent : UiIntent {
@@ -49,14 +47,12 @@ sealed class SignupUiIntent : UiIntent {
     data class SetGender(val gender: GenderType) : SignupUiIntent()
     data object ShowAgreementBottomSheet : SignupUiIntent()
     data object HideAgreementBottomSheet : SignupUiIntent()
-    data class CheckAgreement(
-        val type: AgreementType,
-        val checked: Boolean
-    ) : SignupUiIntent()
+    data class ToggleTermAgreement(val termId: String) : SignupUiIntent()
+    data object ToggleAllTerms : SignupUiIntent()
 
-    data object ShowTermsDialog : SignupUiIntent()
-    data object HideTermsDialog : SignupUiIntent()
-    data object SignupComplete : SignupUiIntent()
+    data class ShowTermsContent(val contentUrl: String) : SignupUiIntent()
+    data object HideTermsContent : SignupUiIntent()
+    data object SubmitAgreement : SignupUiIntent()
     data object DismissError : SignupUiIntent()
 }
 

--- a/feature/signup/src/main/java/com/multissue/wit/feature/signup/state/SignupUiState.kt
+++ b/feature/signup/src/main/java/com/multissue/wit/feature/signup/state/SignupUiState.kt
@@ -19,7 +19,8 @@ data class SignupUiState(
     val showAgreementBottomSheet: Boolean = false,
     val agreementState: AgreementState = AgreementState(),
     val showTermsDialog: Boolean = false,
-    val signupComplete: Boolean = false
+    val signupComplete: Boolean = false,
+    val errorMessage: String? = null
 ) : UiState {
     val hasBirthDate: Boolean
         get() = birthYear != 0 && birthMonth != 0 && birthDay != 0
@@ -56,6 +57,7 @@ sealed class SignupUiIntent : UiIntent {
     data object ShowTermsDialog : SignupUiIntent()
     data object HideTermsDialog : SignupUiIntent()
     data object SignupComplete : SignupUiIntent()
+    data object DismissError : SignupUiIntent()
 }
 
 sealed interface SignupSideEffect : UiSideEffect

--- a/feature/signup/src/main/res/values/strings.xml
+++ b/feature/signup/src/main/res/values/strings.xml
@@ -25,9 +25,8 @@
 
     <string name="agreement_bottom_sheet_title">서비스 이용을 위해\n약관 동의가 필요해요</string>
     <string name="agreement_all_title">전체 동의</string>
-    <string name="agreement_terms_title">이용약관 및 개인정보처리방침 (필수)</string>
-    <string name="agreement_location_title">위치기반서비스 이용약관 (필수)</string>
-    <string name="agreement_marketing_title">마케팅 활용 동의 (선택)</string>
+    <string name="agreement_required">필수</string>
+    <string name="agreement_optional">선택</string>
 
     <string name="complete_signup_title">여행 피드와 동행까지, Wit</string>
     <string name="complete_signup_content">회원가입이 완료되었어요</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,6 +39,7 @@ googleMapsUtils = "4.0.0"
 googleMapsUtilsKtx = "6.0.0"
 datastore = "1.2.0"
 runner = "1.7.0"
+kakaoSdk = "2.20.6"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -114,6 +115,8 @@ play-services-location = { group = "com.google.android.gms", name = "play-servic
 maps-compose = { group = "com.google.maps.android", name = "maps-compose", version.ref = "googleMaps" }
 maps-utils = { group = "com.google.maps.android", name = "android-maps-utils", version.ref = "googleMapsUtils" }
 maps-utils-ktx = { group = "com.google.maps.android", name = "maps-utils-ktx", version.ref = "googleMapsUtilsKtx" }
+
+kakao-user = { group = "com.kakao.sdk", name = "v2-user", version.ref = "kakaoSdk" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -39,7 +39,9 @@ googleMapsUtils = "4.0.0"
 googleMapsUtilsKtx = "6.0.0"
 datastore = "1.2.0"
 runner = "1.7.0"
-kakaoSdk = "2.20.6"
+kakaoSdk = "2.23.2"
+credentials = "1.5.0"
+googleid = "1.2.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -117,6 +119,9 @@ maps-utils = { group = "com.google.maps.android", name = "android-maps-utils", v
 maps-utils-ktx = { group = "com.google.maps.android", name = "maps-utils-ktx", version.ref = "googleMapsUtilsKtx" }
 
 kakao-user = { group = "com.kakao.sdk", name = "v2-user", version.ref = "kakaoSdk" }
+credentials = { group = "androidx.credentials", name = "credentials", version.ref = "credentials" }
+credentials-play-services = { group = "androidx.credentials", name = "credentials-play-services-auth", version.ref = "credentials" }
+googleid = { group = "com.google.android.libraries.identity.googleid", name = "googleid", version.ref = "googleid" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,6 +19,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven { url = uri("https://devrepo.kakao.com/nexus/content/groups/public/") }
     }
 }
 


### PR DESCRIPTION
## Changes 📜
회원과 관련한 API 구현
- 자동 로그인, 로그아웃
- 회원가입 Flow

## Screenshot 📷
| 기능 | 스크린샷 |
| ---- | ----- |
| 로그아웃 Dialog | <img width= "180" height="390" src= "https://github.com/user-attachments/assets/945b4867-ffd2-4343-b52f-cad98bb5715d"/> |
| 에러 Dialog | <img width= "180" height="390" src= "https://github.com/user-attachments/assets/4a4f1796-5386-4d4b-ae7f-eda4b4a7529a"/> |

## Checklist ✅
- [x] 에러 Dialog, 로그아웃 Dialog 확인 (WitErrorDialog, WitReLoginDialog)
- [x] 소셜 로그인 및 회원가입(카카오, 구글)
- [x] 닉네임 중복확인 (`test` 이름의 닉네임으로 가입 완료한 계정이 있어 해당 닉네임으로 테스트 가능)
- [x] 약관동의 (약관 확인 주소에 내용이 아직 없음)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * Kakao, Google 소셜 로그인 추가
  * 회원가입 및 온보딩 플로우 (닉네임, 성별, 생년월일 입력)
  * 약관 동의 및 관리 기능
  * 세션 만료 시 재로그인 다이얼로그
  * 자동 로그인 기능
  * 내 정보 조회 기능
  * 토큰 자동 갱신 및 에러 처리

* **개선 사항**
  * 사용자 친화적 에러 메시지 표시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->